### PR TITLE
[FEAT] 종목 차트 시계열 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/exception/code/ChartErrorCode.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/exception/code/ChartErrorCode.java
@@ -15,9 +15,17 @@ public enum ChartErrorCode implements BaseErrorCode {
       HttpStatus.INTERNAL_SERVER_ERROR, "CHART500_2", "시장 지수 캐시 저장에 실패했습니다."),
   MARKET_INDEX_CACHE_DESERIALIZE_FAILED(
       HttpStatus.INTERNAL_SERVER_ERROR, "CHART500_3", "시장 지수 캐시 조회에 실패했습니다."),
+  RANKING_CACHE_DESERIALIZE_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "CHART500_4", "종목 랭킹 캐시 조회에 실패했습니다."),
   KIS_ACCESS_TOKEN_FAILED(HttpStatus.BAD_GATEWAY, "CHART502_1", "한국투자증권 접근 토큰 발급에 실패했습니다."),
   KIS_RANKING_API_FAILED(HttpStatus.BAD_GATEWAY, "CHART502_2", "한국투자증권 종목 랭킹 조회에 실패했습니다."),
   KIS_APPROVAL_KEY_FAILED(HttpStatus.BAD_GATEWAY, "CHART502_3", "한국투자증권 웹소켓 접속키 발급에 실패했습니다."),
+  KIS_RANKING_RESPONSE_PARSE_FAILED(
+      HttpStatus.BAD_GATEWAY, "CHART502_4", "한국투자증권 종목 랭킹 응답 파싱에 실패했습니다."),
+  KIS_MARKET_INDEX_REALTIME_MESSAGE_INVALID(
+      HttpStatus.BAD_GATEWAY, "CHART502_5", "한국투자증권 실시간 시장 지수 메시지가 올바르지 않습니다."),
+  KIS_MARKET_INDEX_WEBSOCKET_FAILED(
+      HttpStatus.BAD_GATEWAY, "CHART502_6", "한국투자증권 시장 지수 웹소켓 처리에 실패했습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisAccessTokenClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisAccessTokenClient.java
@@ -74,7 +74,8 @@ public class KisAccessTokenClient {
 
       if (response.statusCode() < 200 || response.statusCode() >= 300) {
         log.warn(
-            "{} status={}",
+            "code={}, message={}, status={}",
+            ChartErrorCode.KIS_ACCESS_TOKEN_FAILED.getCode(),
             ChartErrorCode.KIS_ACCESS_TOKEN_FAILED.getMessage(),
             response.statusCode());
         throw new ChartException(ChartErrorCode.KIS_ACCESS_TOKEN_FAILED);
@@ -130,7 +131,10 @@ public class KisAccessTokenClient {
       }
     }
 
-    log.warn("한국투자증권 접근 토큰 발급 대기 시간이 초과되었습니다.");
+    log.warn(
+        "code={}, message={}, reason=wait-timeout",
+        ChartErrorCode.KIS_ACCESS_TOKEN_FAILED.getCode(),
+        ChartErrorCode.KIS_ACCESS_TOKEN_FAILED.getMessage());
     throw new ChartException(ChartErrorCode.KIS_ACCESS_TOKEN_FAILED);
   }
 

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisApprovalKeyClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisApprovalKeyClient.java
@@ -44,7 +44,8 @@ public class KisApprovalKeyClient {
 
       if (response.statusCode() < 200 || response.statusCode() >= 300) {
         log.warn(
-            "{} status={}",
+            "code={}, message={}, status={}",
+            ChartErrorCode.KIS_APPROVAL_KEY_FAILED.getCode(),
             ChartErrorCode.KIS_APPROVAL_KEY_FAILED.getMessage(),
             response.statusCode());
         throw new ChartException(ChartErrorCode.KIS_APPROVAL_KEY_FAILED);

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisMarketIndexWebSocketClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisMarketIndexWebSocketClient.java
@@ -1,6 +1,7 @@
 package com.example.elephantfinancelab_be.domain.chart.service;
 
 import com.example.elephantfinancelab_be.domain.chart.entity.MarketIndexMarket;
+import com.example.elephantfinancelab_be.domain.chart.exception.code.ChartErrorCode;
 import com.example.elephantfinancelab_be.global.config.KisProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -56,7 +57,10 @@ public class KisMarketIndexWebSocketClient {
     }
 
     if (!hasText(kisProperties.getAppKey()) || !hasText(kisProperties.getAppSecret())) {
-      log.warn("한국투자증권 인증 정보가 없어 시장 지수 웹소켓 연결을 건너뜁니다.");
+      log.warn(
+          "code={}, message={}, reason=missing-kis-credentials",
+          ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getCode(),
+          ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getMessage());
       return;
     }
 
@@ -89,14 +93,22 @@ public class KisMarketIndexWebSocketClient {
           .whenComplete(
               (socket, throwable) -> {
                 if (throwable != null) {
-                  log.warn("한국투자증권 시장 지수 웹소켓 연결에 실패했습니다.", throwable);
+                  log.warn(
+                      "code={}, message={}",
+                      ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getCode(),
+                      ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getMessage(),
+                      throwable);
                   scheduleReconnect();
                   return;
                 }
                 webSocket = socket;
               });
     } catch (RuntimeException e) {
-      log.warn("한국투자증권 시장 지수 웹소켓 연결 준비에 실패했습니다.", e);
+      log.warn(
+          "code={}, message={}, phase=prepare-connect",
+          ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getCode(),
+          ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getMessage(),
+          e);
       scheduleReconnect();
     }
   }
@@ -123,13 +135,23 @@ public class KisMarketIndexWebSocketClient {
           .whenComplete(
               (unused, throwable) -> {
                 if (throwable != null) {
-                  log.warn("한국투자증권 시장 지수 구독에 실패했습니다. market={}", market.name(), throwable);
+                  log.warn(
+                      "code={}, message={}, market={}",
+                      ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getCode(),
+                      ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getMessage(),
+                      market.name(),
+                      throwable);
                   return;
                 }
                 log.info("한국투자증권 시장 지수 구독 완료. market={}", market.name());
               });
     } catch (JsonProcessingException e) {
-      log.warn("한국투자증권 시장 지수 구독 메시지 생성에 실패했습니다. market={}", market.name(), e);
+      log.warn(
+          "code={}, message={}, market={}",
+          ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getCode(),
+          ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getMessage(),
+          market.name(),
+          e);
     }
   }
 
@@ -220,7 +242,11 @@ public class KisMarketIndexWebSocketClient {
         try {
           handleMessage(textBuffer.toString());
         } catch (RuntimeException e) {
-          log.warn("한국투자증권 시장 지수 메시지 처리 중 오류가 발생했습니다.", e);
+          log.warn(
+              "code={}, message={}, phase=handle-message",
+              ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getCode(),
+              ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getMessage(),
+              e);
         } finally {
           textBuffer.setLength(0);
         }
@@ -231,14 +257,23 @@ public class KisMarketIndexWebSocketClient {
 
     @Override
     public CompletionStage<?> onClose(WebSocket socket, int statusCode, String reason) {
-      log.warn("한국투자증권 시장 지수 웹소켓 연결 종료. statusCode={}, reason={}", statusCode, reason);
+      log.warn(
+          "code={}, message={}, statusCode={}, reason={}",
+          ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getCode(),
+          ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getMessage(),
+          statusCode,
+          reason);
       scheduleReconnect();
       return CompletableFuture.completedFuture(null);
     }
 
     @Override
     public void onError(WebSocket socket, Throwable error) {
-      log.warn("한국투자증권 시장 지수 웹소켓 오류가 발생했습니다.", error);
+      log.warn(
+          "code={}, message={}",
+          ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getCode(),
+          ChartErrorCode.KIS_MARKET_INDEX_WEBSOCKET_FAILED.getMessage(),
+          error);
       scheduleReconnect();
     }
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisMarketIndexWebSocketClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisMarketIndexWebSocketClient.java
@@ -217,8 +217,13 @@ public class KisMarketIndexWebSocketClient {
     public CompletionStage<?> onText(WebSocket socket, CharSequence data, boolean last) {
       textBuffer.append(data);
       if (last) {
-        handleMessage(textBuffer.toString());
-        textBuffer.setLength(0);
+        try {
+          handleMessage(textBuffer.toString());
+        } catch (RuntimeException e) {
+          log.warn("한국투자증권 시장 지수 메시지 처리 중 오류가 발생했습니다.", e);
+        } finally {
+          textBuffer.setLength(0);
+        }
       }
       socket.request(1);
       return CompletableFuture.completedFuture(null);

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisStockRankingClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisStockRankingClient.java
@@ -57,7 +57,8 @@ public class KisStockRankingClient {
           httpClient.send(request, HttpResponse.BodyHandlers.ofString());
       if (response.statusCode() < 200 || response.statusCode() >= 300) {
         log.warn(
-            "{} status={}",
+            "code={}, message={}, status={}",
+            ChartErrorCode.KIS_RANKING_API_FAILED.getCode(),
             ChartErrorCode.KIS_RANKING_API_FAILED.getMessage(),
             response.statusCode());
         throw new ChartException(ChartErrorCode.KIS_RANKING_API_FAILED);
@@ -66,7 +67,8 @@ public class KisStockRankingClient {
       JsonNode root = objectMapper.readTree(response.body());
       if (!"0".equals(root.path("rt_cd").asText())) {
         log.warn(
-            "{} msg_cd={}, msg={}",
+            "code={}, message={}, msg_cd={}, msg={}",
+            ChartErrorCode.KIS_RANKING_API_FAILED.getCode(),
             ChartErrorCode.KIS_RANKING_API_FAILED.getMessage(),
             root.path("msg_cd").asText(),
             root.path("msg1").asText());
@@ -147,7 +149,12 @@ public class KisStockRankingClient {
     try {
       return Integer.valueOf(normalizeNumericValue(value));
     } catch (NumberFormatException e) {
-      log.warn("한국투자증권 종목 랭킹 응답의 순위 형식이 올바르지 않습니다. field={}, value={}", fieldName, value);
+      log.warn(
+          "code={}, message={}, field={}, value={}",
+          ChartErrorCode.KIS_RANKING_RESPONSE_PARSE_FAILED.getCode(),
+          ChartErrorCode.KIS_RANKING_RESPONSE_PARSE_FAILED.getMessage(),
+          fieldName,
+          value);
       return defaultValue;
     }
   }
@@ -161,7 +168,12 @@ public class KisStockRankingClient {
     try {
       return new BigDecimal(normalizeNumericValue(value)).longValue();
     } catch (NumberFormatException e) {
-      log.warn("한국투자증권 종목 랭킹 응답의 정수 형식이 올바르지 않습니다. field={}, value={}", fieldName, value);
+      log.warn(
+          "code={}, message={}, field={}, value={}",
+          ChartErrorCode.KIS_RANKING_RESPONSE_PARSE_FAILED.getCode(),
+          ChartErrorCode.KIS_RANKING_RESPONSE_PARSE_FAILED.getMessage(),
+          fieldName,
+          value);
       return 0L;
     }
   }
@@ -175,7 +187,12 @@ public class KisStockRankingClient {
     try {
       return new BigDecimal(normalizeNumericValue(value));
     } catch (NumberFormatException e) {
-      log.warn("한국투자증권 종목 랭킹 응답의 숫자 형식이 올바르지 않습니다. field={}, value={}", fieldName, value);
+      log.warn(
+          "code={}, message={}, field={}, value={}",
+          ChartErrorCode.KIS_RANKING_RESPONSE_PARSE_FAILED.getCode(),
+          ChartErrorCode.KIS_RANKING_RESPONSE_PARSE_FAILED.getMessage(),
+          fieldName,
+          value);
       return BigDecimal.ZERO;
     }
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/MarketIndexRealtimeParser.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/MarketIndexRealtimeParser.java
@@ -2,6 +2,7 @@ package com.example.elephantfinancelab_be.domain.chart.service;
 
 import com.example.elephantfinancelab_be.domain.chart.dto.res.MarketIndexResDTO;
 import com.example.elephantfinancelab_be.domain.chart.entity.MarketIndexMarket;
+import com.example.elephantfinancelab_be.domain.chart.exception.code.ChartErrorCode;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -48,13 +49,20 @@ public class MarketIndexRealtimeParser {
     }
 
     if ("1".equals(parts[0])) {
-      log.warn("암호화된 한국투자증권 실시간 지수 메시지는 처리하지 않습니다.");
+      log.warn(
+          "code={}, message={}, reason=encrypted",
+          ChartErrorCode.KIS_MARKET_INDEX_REALTIME_MESSAGE_INVALID.getCode(),
+          ChartErrorCode.KIS_MARKET_INDEX_REALTIME_MESSAGE_INVALID.getMessage());
       return List.of();
     }
 
     String[] fields = parts[3].split("\\^", -1);
     if (fields.length <= CHANGE_RATE_FIELD) {
-      log.warn("한국투자증권 실시간 지수 메시지 필드 수가 부족합니다. count={}", fields.length);
+      log.warn(
+          "code={}, message={}, count={}",
+          ChartErrorCode.KIS_MARKET_INDEX_REALTIME_MESSAGE_INVALID.getCode(),
+          ChartErrorCode.KIS_MARKET_INDEX_REALTIME_MESSAGE_INVALID.getMessage(),
+          fields.length);
       return List.of();
     }
 
@@ -63,7 +71,12 @@ public class MarketIndexRealtimeParser {
     for (int index = 0; index < dataCount; index++) {
       int offset = index * RESPONSE_FIELD_COUNT;
       if (fields.length <= offset + CHANGE_RATE_FIELD) {
-        log.warn("한국투자증권 실시간 지수 메시지 항목 필드 수가 부족합니다. item={}, count={}", index, fields.length);
+        log.warn(
+            "code={}, message={}, item={}, count={}",
+            ChartErrorCode.KIS_MARKET_INDEX_REALTIME_MESSAGE_INVALID.getCode(),
+            ChartErrorCode.KIS_MARKET_INDEX_REALTIME_MESSAGE_INVALID.getMessage(),
+            index,
+            fields.length);
         break;
       }
 
@@ -101,7 +114,11 @@ public class MarketIndexRealtimeParser {
     try {
       return new BigDecimal(value.trim());
     } catch (NumberFormatException e) {
-      log.warn("한국투자증권 실시간 지수 메시지의 숫자 형식이 올바르지 않습니다. value={}", value);
+      log.warn(
+          "code={}, message={}, value={}",
+          ChartErrorCode.KIS_MARKET_INDEX_REALTIME_MESSAGE_INVALID.getCode(),
+          ChartErrorCode.KIS_MARKET_INDEX_REALTIME_MESSAGE_INVALID.getMessage(),
+          value);
       return BigDecimal.ZERO;
     }
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/StockRankingService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/StockRankingService.java
@@ -57,7 +57,12 @@ public class StockRankingService {
     try {
       return objectMapper.readValue(json, RankingResDTO.RankingResponse.class);
     } catch (JsonProcessingException e) {
-      log.warn("종목 랭킹 캐시 역직렬화에 실패했습니다. key={}", type.getRedisKey(), e);
+      log.warn(
+          "code={}, message={}, key={}",
+          ChartErrorCode.RANKING_CACHE_DESERIALIZE_FAILED.getCode(),
+          ChartErrorCode.RANKING_CACHE_DESERIALIZE_FAILED.getMessage(),
+          type.getRedisKey(),
+          e);
       return null;
     }
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/controller/StockController.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/controller/StockController.java
@@ -1,6 +1,8 @@
 package com.example.elephantfinancelab_be.domain.stocks.controller;
 
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockChartResDTO;
 import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.service.query.StockChartQueryService;
 import com.example.elephantfinancelab_be.domain.stocks.service.query.StockQueryService;
 import com.example.elephantfinancelab_be.global.apiPayload.ApiResponse;
 import com.example.elephantfinancelab_be.global.apiPayload.code.GeneralSuccessCode;
@@ -12,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Stocks", description = "종목 관련 API")
@@ -21,12 +24,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class StockController {
 
   private final StockQueryService stockQueryService;
+  private final StockChartQueryService stockChartQueryService;
 
   @Operation(summary = "종목 상세 상단 조회", description = "국내주식 종목명, 현재가, 전일 대비 정보를 조회합니다.")
   @GetMapping("/{ticker}/summary")
   public ResponseEntity<ApiResponse<StockResDTO.Summary>> getSummary(
       @Parameter(description = "종목코드. 예: 005930") @PathVariable String ticker) {
     StockResDTO.Summary result = stockQueryService.getSummary(ticker);
+    return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
+        .body(ApiResponse.of(GeneralSuccessCode.OK, result));
+  }
+
+  @Operation(summary = "종목 차트 시계열 조회", description = "라인/캔들 차트 초기 데이터를 조회합니다.")
+  @GetMapping("/{ticker}/chart")
+  public ResponseEntity<ApiResponse<StockChartResDTO.Chart>> getChart(
+      @Parameter(description = "종목코드. 예: 005930") @PathVariable String ticker,
+      @Parameter(description = "1D, 1W, 3M, 1Y, 5Y, ALL") @RequestParam String range,
+      @Parameter(description = "LINE, CANDLE") @RequestParam String type) {
+    StockChartResDTO.Chart result = stockChartQueryService.getChart(ticker, range, type);
     return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
         .body(ApiResponse.of(GeneralSuccessCode.OK, result));
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/controller/StockController.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/controller/StockController.java
@@ -1,0 +1,33 @@
+package com.example.elephantfinancelab_be.domain.stocks.controller;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.service.query.StockQueryService;
+import com.example.elephantfinancelab_be.global.apiPayload.ApiResponse;
+import com.example.elephantfinancelab_be.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Stocks", description = "종목 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stocks")
+public class StockController {
+
+  private final StockQueryService stockQueryService;
+
+  @Operation(summary = "종목 상세 상단 조회", description = "국내주식 종목명, 현재가, 전일 대비 정보를 조회합니다.")
+  @GetMapping("/{ticker}/summary")
+  public ResponseEntity<ApiResponse<StockResDTO.Summary>> getSummary(
+      @Parameter(description = "종목코드. 예: 005930") @PathVariable String ticker) {
+    StockResDTO.Summary result = stockQueryService.getSummary(ticker);
+    return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
+        .body(ApiResponse.of(GeneralSuccessCode.OK, result));
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/converter/StockConverter.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/converter/StockConverter.java
@@ -1,0 +1,31 @@
+package com.example.elephantfinancelab_be.domain.stocks.converter;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockPriceDirection;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class StockConverter {
+
+  private StockConverter() {}
+
+  public static StockResDTO.Summary toSummary(
+      Stock stock,
+      Long currentPriceKrw,
+      Long changeAmountKrw,
+      BigDecimal changeRate,
+      String signCode,
+      LocalDateTime updatedAt) {
+    return StockResDTO.Summary.builder()
+        .stockName(stock.getName())
+        .ticker(stock.getTicker())
+        .currentPriceKrw(currentPriceKrw)
+        .changeAmountKrw(changeAmountKrw)
+        .changeRate(changeRate)
+        .signCode(signCode)
+        .direction(StockPriceDirection.fromSignCode(signCode))
+        .updatedAt(updatedAt)
+        .build();
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/dto/res/StockChartResDTO.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/dto/res/StockChartResDTO.java
@@ -1,0 +1,19 @@
+package com.example.elephantfinancelab_be.domain.stocks.dto.res;
+
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartInterval;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartType;
+import java.util.List;
+
+public class StockChartResDTO {
+
+  public record Chart(
+      String ticker,
+      String range,
+      StockChartType type,
+      StockChartInterval interval,
+      String currency,
+      List<DataPoint> data) {}
+
+  public record DataPoint(
+      String time, Long price, Long open, Long high, Long low, Long close, Long volume) {}
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/dto/res/StockResDTO.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/dto/res/StockResDTO.java
@@ -1,0 +1,28 @@
+package com.example.elephantfinancelab_be.domain.stocks.dto.res;
+
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockPriceDirection;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class StockResDTO {
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Summary {
+
+    private String stockName;
+    private String ticker;
+    private Long currentPriceKrw;
+    private Long changeAmountKrw;
+    private BigDecimal changeRate;
+    private String signCode;
+    private StockPriceDirection direction;
+    private LocalDateTime updatedAt;
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/Stock.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/Stock.java
@@ -1,0 +1,33 @@
+package com.example.elephantfinancelab_be.domain.stocks.entity;
+
+import com.example.elephantfinancelab_be.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "stocks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Stock extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "ticker", nullable = false, unique = true, length = 20)
+  private String ticker;
+
+  @Column(name = "name", nullable = false, length = 100)
+  private String name;
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/Stock.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/Stock.java
@@ -6,7 +6,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import java.util.Locale;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,4 +33,12 @@ public class Stock extends BaseEntity {
 
   @Column(name = "name", nullable = false, length = 100)
   private String name;
+
+  @PrePersist
+  @PreUpdate
+  private void normalizeTicker() {
+    if (ticker != null) {
+      ticker = ticker.trim().toUpperCase(Locale.ROOT);
+    }
+  }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockChartInterval.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockChartInterval.java
@@ -1,0 +1,9 @@
+package com.example.elephantfinancelab_be.domain.stocks.entity;
+
+public enum StockChartInterval {
+  MINUTE,
+  DAY,
+  WEEK,
+  MONTH,
+  YEAR
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockChartRange.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockChartRange.java
@@ -1,0 +1,47 @@
+package com.example.elephantfinancelab_be.domain.stocks.entity;
+
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockChartRange {
+  ONE_DAY("1D", StockChartInterval.MINUTE, Duration.ofSeconds(30), null),
+  ONE_WEEK("1W", StockChartInterval.DAY, Duration.ofMinutes(1), "D"),
+  THREE_MONTHS("3M", StockChartInterval.DAY, Duration.ofMinutes(5), "D"),
+  ONE_YEAR("1Y", StockChartInterval.DAY, Duration.ofMinutes(10), "D"),
+  FIVE_YEARS("5Y", StockChartInterval.MONTH, Duration.ofMinutes(30), "M"),
+  ALL("ALL", StockChartInterval.YEAR, Duration.ofHours(1), "Y");
+
+  private final String value;
+  private final StockChartInterval interval;
+  private final Duration cacheTtl;
+  private final String kisPeriodDivCode;
+
+  public static StockChartRange from(String value) {
+    if (value == null || value.isBlank()) {
+      throw new StockException(StockErrorCode.INVALID_STOCK_CHART_RANGE);
+    }
+
+    return Arrays.stream(values())
+        .filter(range -> range.value.equalsIgnoreCase(value.trim()))
+        .findFirst()
+        .orElseThrow(() -> new StockException(StockErrorCode.INVALID_STOCK_CHART_RANGE));
+  }
+
+  public LocalDate startDate(LocalDate today) {
+    return switch (this) {
+      case ONE_DAY -> today;
+      case ONE_WEEK -> today.minusWeeks(1);
+      case THREE_MONTHS -> today.minusMonths(3);
+      case ONE_YEAR -> today.minusYears(1);
+      case FIVE_YEARS -> today.minusYears(5);
+      case ALL -> LocalDate.of(1900, 1, 1);
+    };
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockChartType.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockChartType.java
@@ -1,0 +1,21 @@
+package com.example.elephantfinancelab_be.domain.stocks.entity;
+
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import java.util.Arrays;
+
+public enum StockChartType {
+  LINE,
+  CANDLE;
+
+  public static StockChartType from(String value) {
+    if (value == null || value.isBlank()) {
+      throw new StockException(StockErrorCode.INVALID_STOCK_CHART_TYPE);
+    }
+
+    return Arrays.stream(values())
+        .filter(type -> type.name().equalsIgnoreCase(value.trim()))
+        .findFirst()
+        .orElseThrow(() -> new StockException(StockErrorCode.INVALID_STOCK_CHART_TYPE));
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockPriceDirection.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockPriceDirection.java
@@ -7,6 +7,10 @@ public enum StockPriceDirection {
   UNKNOWN;
 
   public static StockPriceDirection fromSignCode(String signCode) {
+    if (signCode == null) {
+      return UNKNOWN;
+    }
+
     return switch (signCode) {
       case "1", "2" -> UP;
       case "3" -> FLAT;

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockPriceDirection.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockPriceDirection.java
@@ -1,0 +1,17 @@
+package com.example.elephantfinancelab_be.domain.stocks.entity;
+
+public enum StockPriceDirection {
+  UP,
+  FLAT,
+  DOWN,
+  UNKNOWN;
+
+  public static StockPriceDirection fromSignCode(String signCode) {
+    return switch (signCode) {
+      case "1", "2" -> UP;
+      case "3" -> FLAT;
+      case "4", "5" -> DOWN;
+      default -> UNKNOWN;
+    };
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/exception/StockException.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/exception/StockException.java
@@ -1,0 +1,21 @@
+package com.example.elephantfinancelab_be.domain.stocks.exception;
+
+import com.example.elephantfinancelab_be.global.apiPayload.code.BaseErrorCode;
+import com.example.elephantfinancelab_be.global.apiPayload.exception.GeneralException;
+
+public class StockException extends GeneralException {
+
+  public StockException(BaseErrorCode code) {
+    super(code);
+  }
+
+  public StockException(BaseErrorCode code, Throwable cause) {
+    super(code);
+    initCause(cause);
+  }
+
+  @Override
+  public String getMessage() {
+    return getCode().getMessage();
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/exception/code/StockErrorCode.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/exception/code/StockErrorCode.java
@@ -1,0 +1,24 @@
+package com.example.elephantfinancelab_be.domain.stocks.exception.code;
+
+import com.example.elephantfinancelab_be.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum StockErrorCode implements BaseErrorCode {
+  STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK404_1", "존재하지 않는 종목입니다."),
+  STOCK_SUMMARY_CACHE_SERIALIZE_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_1", "종목 요약 캐시 저장에 실패했습니다."),
+  STOCK_SUMMARY_CACHE_DESERIALIZE_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_2", "종목 요약 캐시 조회에 실패했습니다."),
+  KIS_STOCK_PRICE_API_FAILED(HttpStatus.BAD_GATEWAY, "STOCK502_1", "한국투자증권 현재가 조회에 실패했습니다."),
+  KIS_STOCK_PRICE_WEBSOCKET_FAILED(
+      HttpStatus.BAD_GATEWAY, "STOCK502_2", "한국투자증권 실시간 체결가 구독에 실패했습니다."),
+  ;
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/exception/code/StockErrorCode.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/exception/code/StockErrorCode.java
@@ -8,14 +8,35 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum StockErrorCode implements BaseErrorCode {
-  STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK404_1", "존재하지 않는 종목입니다."),
+  STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK404_01", "존재하지 않는 종목입니다."),
+  INVALID_STOCK_CHART_RANGE(HttpStatus.BAD_REQUEST, "STOCK400_1", "지원하지 않는 차트 범위입니다."),
+  INVALID_STOCK_CHART_TYPE(HttpStatus.BAD_REQUEST, "STOCK400_2", "지원하지 않는 차트 타입입니다."),
   STOCK_SUMMARY_CACHE_SERIALIZE_FAILED(
       HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_1", "종목 요약 캐시 저장에 실패했습니다."),
   STOCK_SUMMARY_CACHE_DESERIALIZE_FAILED(
       HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_2", "종목 요약 캐시 조회에 실패했습니다."),
+  STOCK_CHART_CACHE_SERIALIZE_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_3", "종목 차트 캐시 저장에 실패했습니다."),
+  STOCK_CHART_CACHE_DESERIALIZE_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_4", "종목 차트 캐시 조회에 실패했습니다."),
+  STOCK_SUMMARY_CACHE_SAVE_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_5", "종목 요약 캐시 저장에 실패했습니다."),
+  STOCK_PRICE_PUSH_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_6", "종목 실시간 체결가 push 전송에 실패했습니다."),
+  STOCK_CHART_REALTIME_UPDATE_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_7", "종목 차트 실시간 업데이트에 실패했습니다."),
+  STOCK_CHART_PUSH_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_8", "종목 차트 실시간 push 전송에 실패했습니다."),
   KIS_STOCK_PRICE_API_FAILED(HttpStatus.BAD_GATEWAY, "STOCK502_1", "한국투자증권 현재가 조회에 실패했습니다."),
   KIS_STOCK_PRICE_WEBSOCKET_FAILED(
       HttpStatus.BAD_GATEWAY, "STOCK502_2", "한국투자증권 실시간 체결가 구독에 실패했습니다."),
+  KIS_STOCK_CHART_API_FAILED(HttpStatus.BAD_GATEWAY, "STOCK502_3", "한국투자증권 종목 차트 조회에 실패했습니다."),
+  KIS_STOCK_PRICE_RESPONSE_PARSE_FAILED(
+      HttpStatus.BAD_GATEWAY, "STOCK502_4", "한국투자증권 현재가 응답 파싱에 실패했습니다."),
+  KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID(
+      HttpStatus.BAD_GATEWAY, "STOCK502_5", "한국투자증권 실시간 체결가 메시지가 올바르지 않습니다."),
+  KIS_STOCK_CHART_RESPONSE_PARSE_FAILED(
+      HttpStatus.BAD_GATEWAY, "STOCK502_6", "한국투자증권 종목 차트 응답 파싱에 실패했습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/repository/StockRepository.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/repository/StockRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
 
-  Optional<Stock> findByTickerIgnoreCase(String ticker);
+  Optional<Stock> findByTicker(String ticker);
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/repository/StockRepository.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/repository/StockRepository.java
@@ -1,0 +1,10 @@
+package com.example.elephantfinancelab_be.domain.stocks.repository;
+
+import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockRepository extends JpaRepository<Stock, Long> {
+
+  Optional<Stock> findByTickerIgnoreCase(String ticker);
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockChartClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockChartClient.java
@@ -1,0 +1,334 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import com.example.elephantfinancelab_be.domain.chart.service.KisAccessTokenClient;
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockChartResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartRange;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import com.example.elephantfinancelab_be.global.config.KisProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class KisStockChartClient {
+
+  private static final String TIME_ITEM_CHART_PATH =
+      "/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice";
+  private static final String DAILY_ITEM_CHART_PATH =
+      "/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice";
+  private static final String TIME_ITEM_CHART_TR_ID = "FHKST03010200";
+  private static final String DAILY_ITEM_CHART_TR_ID = "FHKST03010100";
+  private static final String KRX_MARKET_DIV_CODE = "J";
+  private static final String ADJUSTED_PRICE = "0";
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+  private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+  private static final LocalTime MARKET_OPEN_TIME = LocalTime.of(9, 0);
+  private static final LocalTime MARKET_CLOSE_TIME = LocalTime.of(15, 30);
+  private static final DateTimeFormatter KIS_DATE_FORMATTER = DateTimeFormatter.BASIC_ISO_DATE;
+  private static final DateTimeFormatter KIS_TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmmss");
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+  private static final DateTimeFormatter MINUTE_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+  private final KisProperties kisProperties;
+  private final KisAccessTokenClient accessTokenClient;
+  private final ObjectMapper objectMapper;
+  private final WebClient webClient;
+
+  public KisStockChartClient(
+      KisProperties kisProperties,
+      KisAccessTokenClient accessTokenClient,
+      ObjectMapper objectMapper,
+      WebClient.Builder builder) {
+    this.kisProperties = kisProperties;
+    this.accessTokenClient = accessTokenClient;
+    this.objectMapper = objectMapper;
+    this.webClient = builder.baseUrl(normalizedBaseUrl(kisProperties.getBaseUrl())).build();
+  }
+
+  public List<StockChartResDTO.DataPoint> fetchChart(String ticker, StockChartRange range) {
+    JsonNode root =
+        range == StockChartRange.ONE_DAY
+            ? fetchMinuteChart(ticker)
+            : fetchPeriodChart(ticker, range);
+    if (!"0".equals(root.path("rt_cd").asText())) {
+      log.warn(
+          "code={}, message={}, msg_cd={}, msg={}",
+          StockErrorCode.KIS_STOCK_CHART_API_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_CHART_API_FAILED.getMessage(),
+          root.path("msg_cd").asText(),
+          root.path("msg1").asText());
+      throw new StockException(StockErrorCode.KIS_STOCK_CHART_API_FAILED);
+    }
+
+    List<StockChartResDTO.DataPoint> points =
+        range == StockChartRange.ONE_DAY
+            ? toMinuteDataPoints(root.path("output2"))
+            : toPeriodDataPoints(root.path("output2"));
+    points.sort(Comparator.comparing(StockChartResDTO.DataPoint::time));
+    return points;
+  }
+
+  private JsonNode fetchMinuteChart(String ticker) {
+    String inputHour = minuteChartInputHour();
+    log.debug(
+        "한국투자증권 분봉 차트 API 호출. ticker={}, trId={}, inputHour={}",
+        ticker,
+        TIME_ITEM_CHART_TR_ID,
+        inputHour);
+    return webClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path(TIME_ITEM_CHART_PATH)
+                    .queryParam("FID_COND_MRKT_DIV_CODE", KRX_MARKET_DIV_CODE)
+                    .queryParam("FID_INPUT_ISCD", ticker)
+                    .queryParam("FID_INPUT_HOUR_1", inputHour)
+                    .queryParam("FID_PW_DATA_INCU_YN", "Y")
+                    .queryParam("FID_ETC_CLS_CODE", "")
+                    .build())
+        .headers(headers -> applyKisHeaders(headers, TIME_ITEM_CHART_TR_ID))
+        .retrieve()
+        .onStatus(
+            status -> status.isError(),
+            response ->
+                response
+                    .bodyToMono(String.class)
+                    .defaultIfEmpty("")
+                    .map(body -> stockChartApiException(response.statusCode().value(), body)))
+        .bodyToMono(String.class)
+        .map(this::readTree)
+        .timeout(REQUEST_TIMEOUT)
+        .onErrorMap(this::mapStockChartException)
+        .block();
+  }
+
+  private JsonNode fetchPeriodChart(String ticker, StockChartRange range) {
+    LocalDate today = LocalDate.now(KOREA_ZONE);
+    LocalDate startDate = range.startDate(today);
+    log.debug(
+        "한국투자증권 기간별 차트 API 호출. ticker={}, trId={}, startDate={}, endDate={}, period={}",
+        ticker,
+        DAILY_ITEM_CHART_TR_ID,
+        startDate.format(KIS_DATE_FORMATTER),
+        today.format(KIS_DATE_FORMATTER),
+        range.getKisPeriodDivCode());
+    return webClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path(DAILY_ITEM_CHART_PATH)
+                    .queryParam("FID_COND_MRKT_DIV_CODE", KRX_MARKET_DIV_CODE)
+                    .queryParam("FID_INPUT_ISCD", ticker)
+                    .queryParam("FID_INPUT_DATE_1", startDate.format(KIS_DATE_FORMATTER))
+                    .queryParam("FID_INPUT_DATE_2", today.format(KIS_DATE_FORMATTER))
+                    .queryParam("FID_PERIOD_DIV_CODE", range.getKisPeriodDivCode())
+                    .queryParam("FID_ORG_ADJ_PRC", ADJUSTED_PRICE)
+                    .build())
+        .headers(headers -> applyKisHeaders(headers, DAILY_ITEM_CHART_TR_ID))
+        .retrieve()
+        .onStatus(
+            status -> status.isError(),
+            response ->
+                response
+                    .bodyToMono(String.class)
+                    .defaultIfEmpty("")
+                    .map(body -> stockChartApiException(response.statusCode().value(), body)))
+        .bodyToMono(String.class)
+        .map(this::readTree)
+        .timeout(REQUEST_TIMEOUT)
+        .onErrorMap(this::mapStockChartException)
+        .block();
+  }
+
+  private void applyKisHeaders(HttpHeaders headers, String trId) {
+    headers.setContentType(
+        MediaType.parseMediaType(MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8"));
+    headers.setBearerAuth(accessTokenClient.getAccessToken());
+    headers.set("appkey", kisProperties.getAppKey());
+    headers.set("appsecret", kisProperties.getAppSecret());
+    headers.set("tr_id", trId);
+    headers.set("custtype", "P");
+  }
+
+  private RuntimeException stockChartApiException(int statusCode, String body) {
+    log.warn(
+        "code={}, message={}, status={}, responseBody={}",
+        StockErrorCode.KIS_STOCK_CHART_API_FAILED.getCode(),
+        StockErrorCode.KIS_STOCK_CHART_API_FAILED.getMessage(),
+        statusCode,
+        body);
+    return new StockException(StockErrorCode.KIS_STOCK_CHART_API_FAILED);
+  }
+
+  private Throwable mapStockChartException(Throwable throwable) {
+    if (throwable instanceof StockException) {
+      return throwable;
+    }
+    log.warn(
+        "code={}, message={}, exception={}, detail={}",
+        StockErrorCode.KIS_STOCK_CHART_API_FAILED.getCode(),
+        StockErrorCode.KIS_STOCK_CHART_API_FAILED.getMessage(),
+        throwable.getClass().getSimpleName(),
+        throwable.getMessage());
+    return new StockException(StockErrorCode.KIS_STOCK_CHART_API_FAILED, throwable);
+  }
+
+  private JsonNode readTree(String body) {
+    try {
+      return objectMapper.readTree(body);
+    } catch (JsonProcessingException e) {
+      log.warn(
+          "code={}, message={}, responseBody={}",
+          StockErrorCode.KIS_STOCK_CHART_RESPONSE_PARSE_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_CHART_RESPONSE_PARSE_FAILED.getMessage(),
+          body,
+          e);
+      throw new StockException(StockErrorCode.KIS_STOCK_CHART_RESPONSE_PARSE_FAILED, e);
+    }
+  }
+
+  private String minuteChartInputHour() {
+    LocalTime now = LocalTime.now(KOREA_ZONE).withNano(0);
+    if (now.isBefore(MARKET_OPEN_TIME)) {
+      return MARKET_OPEN_TIME.format(KIS_TIME_FORMATTER);
+    }
+    if (now.isAfter(MARKET_CLOSE_TIME)) {
+      return MARKET_CLOSE_TIME.format(KIS_TIME_FORMATTER);
+    }
+    return now.format(KIS_TIME_FORMATTER);
+  }
+
+  private List<StockChartResDTO.DataPoint> toMinuteDataPoints(JsonNode output) {
+    List<StockChartResDTO.DataPoint> points = new ArrayList<>();
+    if (!output.isArray()) {
+      return points;
+    }
+
+    for (JsonNode node : output) {
+      Long close = positiveLongValue(node, "stck_prpr");
+      points.add(
+          new StockChartResDTO.DataPoint(
+              minuteTime(node),
+              close,
+              positiveLongValue(node, "stck_oprc"),
+              positiveLongValue(node, "stck_hgpr"),
+              positiveLongValue(node, "stck_lwpr"),
+              close,
+              positiveLongValue(node, "cntg_vol")));
+    }
+    return points;
+  }
+
+  private List<StockChartResDTO.DataPoint> toPeriodDataPoints(JsonNode output) {
+    List<StockChartResDTO.DataPoint> points = new ArrayList<>();
+    if (!output.isArray()) {
+      return points;
+    }
+
+    for (JsonNode node : output) {
+      Long close = positiveLongValue(node, "stck_clpr");
+      points.add(
+          new StockChartResDTO.DataPoint(
+              dateTime(node),
+              close,
+              positiveLongValue(node, "stck_oprc"),
+              positiveLongValue(node, "stck_hgpr"),
+              positiveLongValue(node, "stck_lwpr"),
+              close,
+              positiveLongValue(node, "acml_vol")));
+    }
+    return points;
+  }
+
+  private String minuteTime(JsonNode node) {
+    LocalDate date = parseDate(textValue(node, "stck_bsop_date"));
+    LocalTime time = parseTime(textValue(node, "stck_cntg_hour"));
+    return date.atTime(time.withSecond(0)).format(MINUTE_FORMATTER);
+  }
+
+  private String dateTime(JsonNode node) {
+    return parseDate(textValue(node, "stck_bsop_date")).format(DATE_FORMATTER);
+  }
+
+  private LocalDate parseDate(String value) {
+    if (value == null) {
+      return LocalDate.now(KOREA_ZONE);
+    }
+
+    try {
+      return LocalDate.parse(value, KIS_DATE_FORMATTER);
+    } catch (DateTimeParseException e) {
+      log.warn(
+          "code={}, message={}, value={}",
+          StockErrorCode.KIS_STOCK_CHART_RESPONSE_PARSE_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_CHART_RESPONSE_PARSE_FAILED.getMessage(),
+          value);
+      return LocalDate.now(KOREA_ZONE);
+    }
+  }
+
+  private LocalTime parseTime(String value) {
+    if (value == null) {
+      return LocalTime.now(KOREA_ZONE).withSecond(0).withNano(0);
+    }
+
+    try {
+      return LocalTime.parse(value, KIS_TIME_FORMATTER).withSecond(0);
+    } catch (DateTimeParseException e) {
+      log.warn(
+          "code={}, message={}, value={}",
+          StockErrorCode.KIS_STOCK_CHART_RESPONSE_PARSE_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_CHART_RESPONSE_PARSE_FAILED.getMessage(),
+          value);
+      return LocalTime.now(KOREA_ZONE).withSecond(0).withNano(0);
+    }
+  }
+
+  private Long positiveLongValue(JsonNode node, String fieldName) {
+    String value = textValue(node, fieldName);
+    if (value == null) {
+      return 0L;
+    }
+
+    try {
+      return new BigDecimal(value.trim().replace(",", "")).abs().longValue();
+    } catch (NumberFormatException e) {
+      log.warn(
+          "code={}, message={}, field={}, value={}",
+          StockErrorCode.KIS_STOCK_CHART_RESPONSE_PARSE_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_CHART_RESPONSE_PARSE_FAILED.getMessage(),
+          fieldName,
+          value);
+      return 0L;
+    }
+  }
+
+  private String textValue(JsonNode node, String fieldName) {
+    String value = node.path(fieldName).asText();
+    return value.isBlank() ? null : value;
+  }
+
+  private String normalizedBaseUrl(String baseUrl) {
+    return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceClient.java
@@ -1,0 +1,161 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import com.example.elephantfinancelab_be.domain.chart.service.KisAccessTokenClient;
+import com.example.elephantfinancelab_be.domain.stocks.converter.StockConverter;
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockPriceDirection;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import com.example.elephantfinancelab_be.global.config.KisProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KisStockPriceClient {
+
+  private static final String CURRENT_PRICE_PATH =
+      "/uapi/domestic-stock/v1/quotations/inquire-price";
+  private static final String CURRENT_PRICE_TR_ID = "FHKST01010100";
+  private static final String KRX_MARKET_DIV_CODE = "J";
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+  private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+  private final KisProperties kisProperties;
+  private final KisAccessTokenClient accessTokenClient;
+  private final ObjectMapper objectMapper;
+  private final HttpClient httpClient;
+
+  public StockResDTO.Summary fetchSummary(Stock stock) {
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(currentPriceUri(stock.getTicker()))
+              .timeout(REQUEST_TIMEOUT)
+              .header("content-type", MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8")
+              .header("authorization", "Bearer " + accessTokenClient.getAccessToken())
+              .header("appkey", kisProperties.getAppKey())
+              .header("appsecret", kisProperties.getAppSecret())
+              .header("tr_id", CURRENT_PRICE_TR_ID)
+              .header("custtype", "P")
+              .GET()
+              .build();
+
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+        log.warn(
+            "{} status={}",
+            StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getMessage(),
+            response.statusCode());
+        throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
+      }
+
+      JsonNode root = objectMapper.readTree(response.body());
+      if (!"0".equals(root.path("rt_cd").asText())) {
+        log.warn(
+            "{} msg_cd={}, msg={}",
+            StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getMessage(),
+            root.path("msg_cd").asText(),
+            root.path("msg1").asText());
+        throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
+      }
+
+      JsonNode output = root.path("output");
+      String signCode = textValue(output, "prdy_vrss_sign");
+      return StockConverter.toSummary(
+          stock,
+          positiveLongValue(output, "stck_prpr"),
+          signedLongValue(output, "prdy_vrss", signCode),
+          signedDecimalValue(output, "prdy_ctrt", signCode),
+          signCode,
+          LocalDateTime.now(KOREA_ZONE).withNano(0));
+    } catch (IOException e) {
+      throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED, e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED, e);
+    }
+  }
+
+  private URI currentPriceUri(String ticker) {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("FID_COND_MRKT_DIV_CODE", KRX_MARKET_DIV_CODE);
+    params.put("FID_INPUT_ISCD", ticker);
+
+    String baseUrl = kisProperties.getBaseUrl();
+    String normalizedBaseUrl =
+        baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+    return URI.create(normalizedBaseUrl + CURRENT_PRICE_PATH + "?" + queryString(params));
+  }
+
+  private String queryString(Map<String, String> params) {
+    StringJoiner joiner = new StringJoiner("&");
+    params.forEach((key, value) -> joiner.add(encode(key) + "=" + encode(value)));
+    return joiner.toString();
+  }
+
+  private String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+
+  private String textValue(JsonNode node, String fieldName) {
+    String value = node.path(fieldName).asText();
+    return value.isBlank() ? null : value;
+  }
+
+  private Long positiveLongValue(JsonNode node, String fieldName) {
+    return decimalValue(node, fieldName).abs().longValue();
+  }
+
+  private Long signedLongValue(JsonNode node, String fieldName, String signCode) {
+    return applySign(decimalValue(node, fieldName), signCode).longValue();
+  }
+
+  private BigDecimal signedDecimalValue(JsonNode node, String fieldName, String signCode) {
+    return applySign(decimalValue(node, fieldName), signCode);
+  }
+
+  private BigDecimal decimalValue(JsonNode node, String fieldName) {
+    String value = textValue(node, fieldName);
+    if (value == null) {
+      return BigDecimal.ZERO;
+    }
+
+    try {
+      return new BigDecimal(value.trim().replace(",", ""));
+    } catch (NumberFormatException e) {
+      log.warn("한국투자증권 현재가 응답의 숫자 형식이 올바르지 않습니다. field={}, value={}", fieldName, value);
+      return BigDecimal.ZERO;
+    }
+  }
+
+  private BigDecimal applySign(BigDecimal value, String signCode) {
+    StockPriceDirection direction = StockPriceDirection.fromSignCode(signCode);
+    return switch (direction) {
+      case DOWN -> value.abs().negate();
+      case FLAT -> BigDecimal.ZERO;
+      case UP, UNKNOWN -> value.abs();
+    };
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceClient.java
@@ -65,7 +65,8 @@ public class KisStockPriceClient {
           httpClient.send(request, HttpResponse.BodyHandlers.ofString());
       if (response.statusCode() < 200 || response.statusCode() >= 300) {
         log.warn(
-            "{} status={}",
+            "code={}, message={}, status={}",
+            StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getCode(),
             StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getMessage(),
             response.statusCode());
         throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
@@ -74,7 +75,8 @@ public class KisStockPriceClient {
       JsonNode root = objectMapper.readTree(response.body());
       if (!"0".equals(root.path("rt_cd").asText())) {
         log.warn(
-            "{} msg_cd={}, msg={}",
+            "code={}, message={}, msg_cd={}, msg={}",
+            StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getCode(),
             StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getMessage(),
             root.path("msg_cd").asText(),
             root.path("msg1").asText());
@@ -145,7 +147,12 @@ public class KisStockPriceClient {
     try {
       return new BigDecimal(value.trim().replace(",", ""));
     } catch (NumberFormatException e) {
-      log.warn("한국투자증권 현재가 응답의 숫자 형식이 올바르지 않습니다. field={}, value={}", fieldName, value);
+      log.warn(
+          "code={}, message={}, field={}, value={}",
+          StockErrorCode.KIS_STOCK_PRICE_RESPONSE_PARSE_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_PRICE_RESPONSE_PARSE_FAILED.getMessage(),
+          fieldName,
+          value);
       return BigDecimal.ZERO;
     }
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceWebSocketClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceWebSocketClient.java
@@ -1,0 +1,263 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import com.example.elephantfinancelab_be.domain.chart.service.KisApprovalKeyClient;
+import com.example.elephantfinancelab_be.global.config.KisProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PreDestroy;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KisStockPriceWebSocketClient {
+
+  private static final Duration RECONNECT_DELAY = Duration.ofSeconds(10);
+
+  private final KisProperties kisProperties;
+  private final KisApprovalKeyClient approvalKeyClient;
+  private final StockPriceRealtimeParser stockPriceRealtimeParser;
+  private final StockPricePushService stockPricePushService;
+  private final ObjectMapper objectMapper;
+  private final HttpClient httpClient;
+  private final Set<String> subscribedTickers = ConcurrentHashMap.newKeySet();
+  private final ScheduledExecutorService reconnectExecutor =
+      Executors.newSingleThreadScheduledExecutor(
+          runnable -> {
+            Thread thread = new Thread(runnable, "kis-stock-price-ws-reconnect");
+            thread.setDaemon(true);
+            return thread;
+          });
+  private final AtomicBoolean running = new AtomicBoolean(false);
+  private final AtomicBoolean connecting = new AtomicBoolean(false);
+  private final AtomicBoolean reconnectScheduled = new AtomicBoolean(false);
+
+  private volatile String approvalKey;
+  private volatile WebSocket webSocket;
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void start() {
+    if (!kisProperties.isWebsocketEnabled()) {
+      log.info("한국투자증권 종목 체결가 웹소켓이 비활성화되어 있습니다.");
+      return;
+    }
+
+    if (!hasText(kisProperties.getAppKey()) || !hasText(kisProperties.getAppSecret())) {
+      log.warn("한국투자증권 인증 정보가 없어 종목 체결가 웹소켓 연결을 건너뜁니다.");
+      return;
+    }
+
+    running.set(true);
+    connect();
+  }
+
+  public void subscribe(String ticker) {
+    String normalizedTicker = normalizeTicker(ticker);
+    if (normalizedTicker == null) {
+      return;
+    }
+
+    boolean added = subscribedTickers.add(normalizedTicker);
+    WebSocket currentWebSocket = webSocket;
+    String currentApprovalKey = approvalKey;
+    if (added && currentWebSocket != null && currentApprovalKey != null) {
+      subscribe(currentWebSocket, currentApprovalKey, normalizedTicker);
+    }
+  }
+
+  @PreDestroy
+  public void stop() {
+    running.set(false);
+    WebSocket currentWebSocket = webSocket;
+    if (currentWebSocket != null) {
+      currentWebSocket.sendClose(WebSocket.NORMAL_CLOSURE, "서버 종료");
+    }
+    reconnectExecutor.shutdownNow();
+  }
+
+  private void connect() {
+    if (!running.get() || !connecting.compareAndSet(false, true)) {
+      return;
+    }
+
+    try {
+      String issuedApprovalKey = approvalKeyClient.issueApprovalKey();
+      httpClient
+          .newWebSocketBuilder()
+          .connectTimeout(Duration.ofSeconds(10))
+          .buildAsync(
+              URI.create(kisProperties.getWebsocketUrl()),
+              new KisWebSocketListener(issuedApprovalKey))
+          .whenComplete(
+              (socket, throwable) -> {
+                connecting.set(false);
+                if (throwable != null) {
+                  log.warn("한국투자증권 종목 체결가 웹소켓 연결에 실패했습니다.", throwable);
+                  scheduleReconnect();
+                  return;
+                }
+                approvalKey = issuedApprovalKey;
+                webSocket = socket;
+              });
+    } catch (RuntimeException e) {
+      connecting.set(false);
+      log.warn("한국투자증권 종목 체결가 웹소켓 연결 준비에 실패했습니다.", e);
+      scheduleReconnect();
+    }
+  }
+
+  private void scheduleReconnect() {
+    if (!running.get() || !reconnectScheduled.compareAndSet(false, true)) {
+      return;
+    }
+
+    log.info("한국투자증권 종목 체결가 웹소켓 재연결을 {}초 후 시도합니다.", RECONNECT_DELAY.toSeconds());
+    reconnectExecutor.schedule(
+        () -> {
+          reconnectScheduled.set(false);
+          connect();
+        },
+        RECONNECT_DELAY.toSeconds(),
+        TimeUnit.SECONDS);
+  }
+
+  private void subscribe(WebSocket socket, String approvalKey, String ticker) {
+    try {
+      socket
+          .sendText(subscriptionMessage(approvalKey, ticker), true)
+          .whenComplete(
+              (unused, throwable) -> {
+                if (throwable != null) {
+                  log.warn("한국투자증권 종목 체결가 구독에 실패했습니다. ticker={}", ticker, throwable);
+                  return;
+                }
+                log.info("한국투자증권 종목 체결가 구독 완료. ticker={}", ticker);
+              });
+    } catch (JsonProcessingException e) {
+      log.warn("한국투자증권 종목 체결가 구독 메시지 생성에 실패했습니다. ticker={}", ticker, e);
+    }
+  }
+
+  private String subscriptionMessage(String approvalKey, String ticker)
+      throws JsonProcessingException {
+    return objectMapper.writeValueAsString(
+        Map.of(
+            "header",
+            Map.of(
+                "approval_key",
+                approvalKey,
+                "custtype",
+                "P",
+                "tr_type",
+                "1",
+                "content-type",
+                "utf-8"),
+            "body",
+            Map.of(
+                "input",
+                Map.of(
+                    "tr_id",
+                    StockPriceRealtimeParser.DOMESTIC_STOCK_REALTIME_TR_ID,
+                    "tr_key",
+                    ticker))));
+  }
+
+  private void handleMessage(String message) {
+    if (message.startsWith("{")) {
+      logSubscriptionResponse(message);
+      return;
+    }
+
+    stockPriceRealtimeParser.parseAll(message).forEach(stockPricePushService::updateAndPush);
+  }
+
+  private void logSubscriptionResponse(String message) {
+    try {
+      JsonNode root = objectMapper.readTree(message);
+      JsonNode header = root.path("header");
+      JsonNode body = root.path("body");
+      log.info(
+          "한국투자증권 종목 체결가 웹소켓 응답. tr_id={}, tr_key={}, rt_cd={}, msg_cd={}",
+          header.path("tr_id").asText(),
+          header.path("tr_key").asText(),
+          body.path("rt_cd").asText(),
+          body.path("msg_cd").asText());
+    } catch (JsonProcessingException e) {
+      log.debug("한국투자증권 종목 체결가 웹소켓 비데이터 메시지를 수신했습니다.");
+    }
+  }
+
+  private String normalizeTicker(String ticker) {
+    if (ticker == null || ticker.isBlank()) {
+      return null;
+    }
+    return ticker.trim().toUpperCase();
+  }
+
+  private boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
+
+  private class KisWebSocketListener implements WebSocket.Listener {
+
+    private final String approvalKey;
+    private final StringBuilder textBuffer = new StringBuilder();
+
+    private KisWebSocketListener(String approvalKey) {
+      this.approvalKey = approvalKey;
+    }
+
+    @Override
+    public void onOpen(WebSocket socket) {
+      log.info("한국투자증권 종목 체결가 웹소켓 연결 완료");
+      WebSocket.Listener.super.onOpen(socket);
+      subscribedTickers.forEach(ticker -> subscribe(socket, approvalKey, ticker));
+    }
+
+    @Override
+    public CompletionStage<?> onText(WebSocket socket, CharSequence data, boolean last) {
+      textBuffer.append(data);
+      if (last) {
+        handleMessage(textBuffer.toString());
+        textBuffer.setLength(0);
+      }
+      socket.request(1);
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<?> onClose(WebSocket socket, int statusCode, String reason) {
+      log.warn("한국투자증권 종목 체결가 웹소켓 연결 종료. statusCode={}, reason={}", statusCode, reason);
+      webSocket = null;
+      KisStockPriceWebSocketClient.this.approvalKey = null;
+      scheduleReconnect();
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void onError(WebSocket socket, Throwable error) {
+      log.warn("한국투자증권 종목 체결가 웹소켓 오류가 발생했습니다.", error);
+      webSocket = null;
+      KisStockPriceWebSocketClient.this.approvalKey = null;
+      scheduleReconnect();
+    }
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceWebSocketClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceWebSocketClient.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.WebSocket;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -209,7 +210,7 @@ public class KisStockPriceWebSocketClient {
     if (ticker == null || ticker.isBlank()) {
       return null;
     }
-    return ticker.trim().toUpperCase();
+    return ticker.trim().toUpperCase(Locale.ROOT);
   }
 
   private boolean hasText(String value) {
@@ -236,8 +237,13 @@ public class KisStockPriceWebSocketClient {
     public CompletionStage<?> onText(WebSocket socket, CharSequence data, boolean last) {
       textBuffer.append(data);
       if (last) {
-        handleMessage(textBuffer.toString());
-        textBuffer.setLength(0);
+        try {
+          handleMessage(textBuffer.toString());
+        } catch (RuntimeException e) {
+          log.warn("한국투자증권 종목 체결가 메시지 처리 중 오류가 발생했습니다.", e);
+        } finally {
+          textBuffer.setLength(0);
+        }
       }
       socket.request(1);
       return CompletableFuture.completedFuture(null);

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceWebSocketClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceWebSocketClient.java
@@ -1,6 +1,7 @@
 package com.example.elephantfinancelab_be.domain.stocks.service;
 
 import com.example.elephantfinancelab_be.domain.chart.service.KisApprovalKeyClient;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
 import com.example.elephantfinancelab_be.global.config.KisProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -62,7 +63,10 @@ public class KisStockPriceWebSocketClient {
     }
 
     if (!hasText(kisProperties.getAppKey()) || !hasText(kisProperties.getAppSecret())) {
-      log.warn("한국투자증권 인증 정보가 없어 종목 체결가 웹소켓 연결을 건너뜁니다.");
+      log.warn(
+          "code={}, message={}, reason=missing-kis-credentials",
+          StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getMessage());
       return;
     }
 
@@ -111,7 +115,11 @@ public class KisStockPriceWebSocketClient {
               (socket, throwable) -> {
                 connecting.set(false);
                 if (throwable != null) {
-                  log.warn("한국투자증권 종목 체결가 웹소켓 연결에 실패했습니다.", throwable);
+                  log.warn(
+                      "code={}, message={}",
+                      StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getCode(),
+                      StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getMessage(),
+                      throwable);
                   scheduleReconnect();
                   return;
                 }
@@ -120,7 +128,11 @@ public class KisStockPriceWebSocketClient {
               });
     } catch (RuntimeException e) {
       connecting.set(false);
-      log.warn("한국투자증권 종목 체결가 웹소켓 연결 준비에 실패했습니다.", e);
+      log.warn(
+          "code={}, message={}, phase=prepare-connect",
+          StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getMessage(),
+          e);
       scheduleReconnect();
     }
   }
@@ -147,13 +159,23 @@ public class KisStockPriceWebSocketClient {
           .whenComplete(
               (unused, throwable) -> {
                 if (throwable != null) {
-                  log.warn("한국투자증권 종목 체결가 구독에 실패했습니다. ticker={}", ticker, throwable);
+                  log.warn(
+                      "code={}, message={}, ticker={}",
+                      StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getCode(),
+                      StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getMessage(),
+                      ticker,
+                      throwable);
                   return;
                 }
                 log.info("한국투자증권 종목 체결가 구독 완료. ticker={}", ticker);
               });
     } catch (JsonProcessingException e) {
-      log.warn("한국투자증권 종목 체결가 구독 메시지 생성에 실패했습니다. ticker={}", ticker, e);
+      log.warn(
+          "code={}, message={}, ticker={}",
+          StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getMessage(),
+          ticker,
+          e);
     }
   }
 
@@ -240,7 +262,11 @@ public class KisStockPriceWebSocketClient {
         try {
           handleMessage(textBuffer.toString());
         } catch (RuntimeException e) {
-          log.warn("한국투자증권 종목 체결가 메시지 처리 중 오류가 발생했습니다.", e);
+          log.warn(
+              "code={}, message={}, phase=handle-message",
+              StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getCode(),
+              StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getMessage(),
+              e);
         } finally {
           textBuffer.setLength(0);
         }
@@ -251,7 +277,12 @@ public class KisStockPriceWebSocketClient {
 
     @Override
     public CompletionStage<?> onClose(WebSocket socket, int statusCode, String reason) {
-      log.warn("한국투자증권 종목 체결가 웹소켓 연결 종료. statusCode={}, reason={}", statusCode, reason);
+      log.warn(
+          "code={}, message={}, statusCode={}, reason={}",
+          StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getMessage(),
+          statusCode,
+          reason);
       webSocket = null;
       KisStockPriceWebSocketClient.this.approvalKey = null;
       scheduleReconnect();
@@ -260,7 +291,11 @@ public class KisStockPriceWebSocketClient {
 
     @Override
     public void onError(WebSocket socket, Throwable error) {
-      log.warn("한국투자증권 종목 체결가 웹소켓 오류가 발생했습니다.", error);
+      log.warn(
+          "code={}, message={}",
+          StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_PRICE_WEBSOCKET_FAILED.getMessage(),
+          error);
       webSocket = null;
       KisStockPriceWebSocketClient.this.approvalKey = null;
       scheduleReconnect();

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockChartRealtimeService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockChartRealtimeService.java
@@ -1,0 +1,147 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockChartResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartRange;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartType;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockChartRealtimeService {
+
+  private static final DateTimeFormatter MINUTE_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+  private final StockChartRedisService stockChartRedisService;
+  private final SimpMessagingTemplate messagingTemplate;
+
+  public void updateAndPush(String ticker, StockPriceRealtimeParser.ParsedStockPrice parsed) {
+    Flux.fromArray(StockChartType.values())
+        .flatMap(
+            type ->
+                Mono.justOrEmpty(
+                    stockChartRedisService.find(ticker, StockChartRange.ONE_DAY, type)))
+        .map(chart -> updateChart(chart, parsed))
+        .doOnNext(stockChartRedisService::save)
+        .doOnNext(this::push)
+        .doOnError(
+            error ->
+                log.warn(
+                    "code={}, message={}, ticker={}",
+                    StockErrorCode.STOCK_CHART_REALTIME_UPDATE_FAILED.getCode(),
+                    StockErrorCode.STOCK_CHART_REALTIME_UPDATE_FAILED.getMessage(),
+                    ticker,
+                    error))
+        .subscribe();
+  }
+
+  private StockChartResDTO.Chart updateChart(
+      StockChartResDTO.Chart chart, StockPriceRealtimeParser.ParsedStockPrice parsed) {
+    List<StockChartResDTO.DataPoint> data = new ArrayList<>(chart.data());
+    String minuteTime = minuteTime(parsed.updatedAt());
+    StockChartResDTO.DataPoint realtimePoint = newPoint(minuteTime, parsed);
+
+    if (data.isEmpty()) {
+      data.add(realtimePoint);
+      return chartWithData(chart, data);
+    }
+
+    int lastIndex = data.size() - 1;
+    StockChartResDTO.DataPoint lastPoint = data.get(lastIndex);
+    if (minuteTime.equals(lastPoint.time())) {
+      data.set(lastIndex, mergePoint(chart.type(), lastPoint, parsed));
+    } else {
+      data.add(realtimePoint);
+    }
+
+    return chartWithData(chart, data);
+  }
+
+  private StockChartResDTO.DataPoint mergePoint(
+      StockChartType type,
+      StockChartResDTO.DataPoint previous,
+      StockPriceRealtimeParser.ParsedStockPrice parsed) {
+    Long price = parsed.currentPriceKrw();
+    if (type == StockChartType.LINE) {
+      return new StockChartResDTO.DataPoint(
+          previous.time(),
+          price,
+          previous.open(),
+          previous.high(),
+          previous.low(),
+          price,
+          previous.volume());
+    }
+
+    return new StockChartResDTO.DataPoint(
+        previous.time(),
+        price,
+        previous.open(),
+        max(previous.high(), price),
+        min(previous.low(), price),
+        price,
+        safeLong(previous.volume()) + safeLong(parsed.tradeVolume()));
+  }
+
+  private StockChartResDTO.DataPoint newPoint(
+      String minuteTime, StockPriceRealtimeParser.ParsedStockPrice parsed) {
+    Long price = parsed.currentPriceKrw();
+    return new StockChartResDTO.DataPoint(
+        minuteTime, price, price, price, price, price, safeLong(parsed.tradeVolume()));
+  }
+
+  private StockChartResDTO.Chart chartWithData(
+      StockChartResDTO.Chart chart, List<StockChartResDTO.DataPoint> data) {
+    return new StockChartResDTO.Chart(
+        chart.ticker(), chart.range(), chart.type(), chart.interval(), chart.currency(), data);
+  }
+
+  private void push(StockChartResDTO.Chart chart) {
+    try {
+      messagingTemplate.convertAndSend(destination(chart.ticker()), chart);
+      log.debug("종목 1D 차트 실시간 push 완료. ticker={}, type={}", chart.ticker(), chart.type());
+    } catch (RuntimeException e) {
+      log.warn(
+          "code={}, message={}, ticker={}",
+          StockErrorCode.STOCK_CHART_PUSH_FAILED.getCode(),
+          StockErrorCode.STOCK_CHART_PUSH_FAILED.getMessage(),
+          chart.ticker(),
+          e);
+    }
+  }
+
+  private String destination(String ticker) {
+    return "/topic/stocks/" + ticker.trim().toUpperCase(Locale.ROOT) + "/chart";
+  }
+
+  private String minuteTime(LocalDateTime updatedAt) {
+    return updatedAt.withSecond(0).withNano(0).format(MINUTE_FORMATTER);
+  }
+
+  private Long max(Long left, Long right) {
+    return Math.max(safeLong(left), safeLong(right));
+  }
+
+  private Long min(Long left, Long right) {
+    if (left == null || left == 0L) {
+      return safeLong(right);
+    }
+    return Math.min(left, safeLong(right));
+  }
+
+  private Long safeLong(Long value) {
+    return value == null ? 0L : value;
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockChartRedisService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockChartRedisService.java
@@ -1,0 +1,62 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockChartResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartRange;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartType;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StockChartRedisService {
+
+  private static final String CHART_KEY_PREFIX = "stock:chart:";
+
+  private final StringRedisTemplate stringRedisTemplate;
+  private final ObjectMapper objectMapper;
+
+  public void save(StockChartResDTO.Chart chart) {
+    try {
+      stringRedisTemplate
+          .opsForValue()
+          .set(
+              redisKey(chart.ticker(), StockChartRange.from(chart.range()), chart.type()),
+              objectMapper.writeValueAsString(chart),
+              StockChartRange.from(chart.range()).getCacheTtl());
+    } catch (JsonProcessingException e) {
+      throw new StockException(StockErrorCode.STOCK_CHART_CACHE_SERIALIZE_FAILED, e);
+    }
+  }
+
+  public StockChartResDTO.Chart find(String ticker, StockChartRange range, StockChartType type) {
+    String json = stringRedisTemplate.opsForValue().get(redisKey(ticker, range, type));
+    if (json == null || json.isBlank()) {
+      return null;
+    }
+
+    try {
+      return objectMapper.readValue(json, StockChartResDTO.Chart.class);
+    } catch (JsonProcessingException e) {
+      throw new StockException(StockErrorCode.STOCK_CHART_CACHE_DESERIALIZE_FAILED, e);
+    }
+  }
+
+  public boolean exists(String ticker, StockChartRange range, StockChartType type) {
+    return Boolean.TRUE.equals(stringRedisTemplate.hasKey(redisKey(ticker, range, type)));
+  }
+
+  private String redisKey(String ticker, StockChartRange range, StockChartType type) {
+    return CHART_KEY_PREFIX
+        + ticker.trim().toUpperCase(Locale.ROOT)
+        + ":"
+        + range.getValue()
+        + ":"
+        + type.name();
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPricePushService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPricePushService.java
@@ -3,6 +3,7 @@ package com.example.elephantfinancelab_be.domain.stocks.service;
 import com.example.elephantfinancelab_be.domain.stocks.converter.StockConverter;
 import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
 import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
 import com.example.elephantfinancelab_be.domain.stocks.repository.StockRepository;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class StockPricePushService {
 
   private final StockRepository stockRepository;
   private final StockSummaryRedisService stockSummaryRedisService;
+  private final StockChartRealtimeService stockChartRealtimeService;
   private final SimpMessagingTemplate messagingTemplate;
 
   public void updateAndPush(StockPriceRealtimeParser.ParsedStockPrice parsed) {
@@ -46,15 +48,27 @@ public class StockPricePushService {
     try {
       stockSummaryRedisService.save(summary);
     } catch (RuntimeException e) {
-      log.warn("종목 요약 Redis 저장에 실패했습니다. ticker={}", stock.getTicker(), e);
+      log.warn(
+          "code={}, message={}, ticker={}",
+          StockErrorCode.STOCK_SUMMARY_CACHE_SAVE_FAILED.getCode(),
+          StockErrorCode.STOCK_SUMMARY_CACHE_SAVE_FAILED.getMessage(),
+          stock.getTicker(),
+          e);
     }
 
     try {
       messagingTemplate.convertAndSend(destination(stock.getTicker()), summary);
       log.debug("종목 실시간 체결가 push 완료. ticker={}", stock.getTicker());
     } catch (RuntimeException e) {
-      log.warn("종목 실시간 체결가 push 전송에 실패했습니다. ticker={}", stock.getTicker(), e);
+      log.warn(
+          "code={}, message={}, ticker={}",
+          StockErrorCode.STOCK_PRICE_PUSH_FAILED.getCode(),
+          StockErrorCode.STOCK_PRICE_PUSH_FAILED.getMessage(),
+          stock.getTicker(),
+          e);
     }
+
+    stockChartRealtimeService.updateAndPush(stock.getTicker(), parsed);
   }
 
   private String destination(String ticker) {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPricePushService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPricePushService.java
@@ -1,0 +1,47 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import com.example.elephantfinancelab_be.domain.stocks.converter.StockConverter;
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockPricePushService {
+
+  private final StockRepository stockRepository;
+  private final StockSummaryRedisService stockSummaryRedisService;
+  private final SimpMessagingTemplate messagingTemplate;
+
+  public void updateAndPush(StockPriceRealtimeParser.ParsedStockPrice parsed) {
+    stockRepository
+        .findByTickerIgnoreCase(parsed.ticker())
+        .ifPresentOrElse(
+            stock -> updateAndPush(stock, parsed),
+            () -> log.debug("DB에 없는 종목 실시간 체결가를 건너뜁니다. ticker={}", parsed.ticker()));
+  }
+
+  private void updateAndPush(Stock stock, StockPriceRealtimeParser.ParsedStockPrice parsed) {
+    StockResDTO.Summary summary =
+        StockConverter.toSummary(
+            stock,
+            parsed.currentPriceKrw(),
+            parsed.changeAmountKrw(),
+            parsed.changeRate(),
+            parsed.signCode(),
+            parsed.updatedAt());
+
+    stockSummaryRedisService.save(summary);
+    messagingTemplate.convertAndSend(destination(stock.getTicker()), summary);
+    log.debug("종목 실시간 체결가 push 완료. ticker={}", stock.getTicker());
+  }
+
+  private String destination(String ticker) {
+    return "/topic/stocks/" + ticker.trim().toUpperCase() + "/price";
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPricePushService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPricePushService.java
@@ -4,6 +4,7 @@ import com.example.elephantfinancelab_be.domain.stocks.converter.StockConverter;
 import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
 import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
 import com.example.elephantfinancelab_be.domain.stocks.repository.StockRepository;
+import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -19,11 +20,17 @@ public class StockPricePushService {
   private final SimpMessagingTemplate messagingTemplate;
 
   public void updateAndPush(StockPriceRealtimeParser.ParsedStockPrice parsed) {
+    String ticker = normalizeTicker(parsed.ticker());
+    if (ticker == null) {
+      log.debug("종목코드가 없는 실시간 체결가를 건너뜁니다.");
+      return;
+    }
+
     stockRepository
-        .findByTickerIgnoreCase(parsed.ticker())
+        .findByTicker(ticker)
         .ifPresentOrElse(
             stock -> updateAndPush(stock, parsed),
-            () -> log.debug("DB에 없는 종목 실시간 체결가를 건너뜁니다. ticker={}", parsed.ticker()));
+            () -> log.debug("DB에 없는 종목 실시간 체결가를 건너뜁니다. ticker={}", ticker));
   }
 
   private void updateAndPush(Stock stock, StockPriceRealtimeParser.ParsedStockPrice parsed) {
@@ -36,12 +43,28 @@ public class StockPricePushService {
             parsed.signCode(),
             parsed.updatedAt());
 
-    stockSummaryRedisService.save(summary);
-    messagingTemplate.convertAndSend(destination(stock.getTicker()), summary);
-    log.debug("종목 실시간 체결가 push 완료. ticker={}", stock.getTicker());
+    try {
+      stockSummaryRedisService.save(summary);
+    } catch (RuntimeException e) {
+      log.warn("종목 요약 Redis 저장에 실패했습니다. ticker={}", stock.getTicker(), e);
+    }
+
+    try {
+      messagingTemplate.convertAndSend(destination(stock.getTicker()), summary);
+      log.debug("종목 실시간 체결가 push 완료. ticker={}", stock.getTicker());
+    } catch (RuntimeException e) {
+      log.warn("종목 실시간 체결가 push 전송에 실패했습니다. ticker={}", stock.getTicker(), e);
+    }
   }
 
   private String destination(String ticker) {
-    return "/topic/stocks/" + ticker.trim().toUpperCase() + "/price";
+    return "/topic/stocks/" + ticker.trim().toUpperCase(Locale.ROOT) + "/price";
+  }
+
+  private String normalizeTicker(String ticker) {
+    if (ticker == null || ticker.isBlank()) {
+      return null;
+    }
+    return ticker.trim().toUpperCase(Locale.ROOT);
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParser.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParser.java
@@ -1,6 +1,7 @@
 package com.example.elephantfinancelab_be.domain.stocks.service;
 
 import com.example.elephantfinancelab_be.domain.stocks.entity.StockPriceDirection;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -32,6 +33,8 @@ public class StockPriceRealtimeParser {
   private static final int CHANGE_SIGN_FIELD = 3;
   private static final int CHANGE_AMOUNT_FIELD = 4;
   private static final int CHANGE_RATE_FIELD = 5;
+  private static final int TRADE_VOLUME_FIELD = 12;
+  private static final int ACCUMULATED_VOLUME_FIELD = 13;
   private static final int BUSINESS_DATE_FIELD = 33;
 
   public Optional<ParsedStockPrice> parse(String message) {
@@ -49,13 +52,20 @@ public class StockPriceRealtimeParser {
     }
 
     if ("1".equals(parts[0])) {
-      log.warn("암호화된 한국투자증권 실시간 체결가 메시지는 처리하지 않습니다.");
+      log.warn(
+          "code={}, message={}, reason=encrypted",
+          StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getCode(),
+          StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getMessage());
       return List.of();
     }
 
     String[] fields = parts[3].split("\\^", -1);
     if (fields.length <= CHANGE_RATE_FIELD) {
-      log.warn("한국투자증권 실시간 체결가 메시지 필드 수가 부족합니다. count={}", fields.length);
+      log.warn(
+          "code={}, message={}, count={}",
+          StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getCode(),
+          StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getMessage(),
+          fields.length);
       return List.of();
     }
 
@@ -64,7 +74,12 @@ public class StockPriceRealtimeParser {
     for (int index = 0; index < dataCount; index++) {
       int offset = index * RESPONSE_FIELD_COUNT;
       if (fields.length <= offset + CHANGE_RATE_FIELD) {
-        log.warn("한국투자증권 실시간 체결가 메시지 항목 필드 수가 부족합니다. item={}, count={}", index, fields.length);
+        log.warn(
+            "code={}, message={}, item={}, count={}",
+            StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getCode(),
+            StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getMessage(),
+            index,
+            fields.length);
         break;
       }
       prices.add(toParsedStockPrice(fields, offset));
@@ -82,6 +97,8 @@ public class StockPriceRealtimeParser {
         applySign(parseDecimal(fields[offset + CHANGE_RATE_FIELD]), signCode),
         signCode,
         StockPriceDirection.fromSignCode(signCode),
+        parseDecimal(fieldValue(fields, offset + TRADE_VOLUME_FIELD)).abs().longValue(),
+        parseDecimal(fieldValue(fields, offset + ACCUMULATED_VOLUME_FIELD)).abs().longValue(),
         parseTimestamp(
             fieldValue(fields, offset + BUSINESS_DATE_FIELD),
             fieldValue(fields, offset + TRADE_TIME_FIELD)));
@@ -109,7 +126,11 @@ public class StockPriceRealtimeParser {
     try {
       return new BigDecimal(value.trim().replace(",", ""));
     } catch (NumberFormatException e) {
-      log.warn("한국투자증권 실시간 체결가 메시지의 숫자 형식이 올바르지 않습니다. value={}", value);
+      log.warn(
+          "code={}, message={}, value={}",
+          StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getCode(),
+          StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getMessage(),
+          value);
       return BigDecimal.ZERO;
     }
   }
@@ -161,5 +182,7 @@ public class StockPriceRealtimeParser {
       BigDecimal changeRate,
       String signCode,
       StockPriceDirection direction,
+      Long tradeVolume,
+      Long accumulatedVolume,
       LocalDateTime updatedAt) {}
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParser.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParser.java
@@ -1,0 +1,165 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockPriceDirection;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class StockPriceRealtimeParser {
+
+  public static final String DOMESTIC_STOCK_REALTIME_TR_ID = "H0STCNT0";
+
+  private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+  private static final DateTimeFormatter KIS_DATE_FORMATTER = DateTimeFormatter.BASIC_ISO_DATE;
+  private static final DateTimeFormatter KIS_TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmmss");
+  private static final Duration FUTURE_TIMESTAMP_TOLERANCE = Duration.ofHours(1);
+  private static final int RESPONSE_FIELD_COUNT = 46;
+  private static final int TICKER_FIELD = 0;
+  private static final int TRADE_TIME_FIELD = 1;
+  private static final int CURRENT_PRICE_FIELD = 2;
+  private static final int CHANGE_SIGN_FIELD = 3;
+  private static final int CHANGE_AMOUNT_FIELD = 4;
+  private static final int CHANGE_RATE_FIELD = 5;
+  private static final int BUSINESS_DATE_FIELD = 33;
+
+  public Optional<ParsedStockPrice> parse(String message) {
+    return parseAll(message).stream().findFirst();
+  }
+
+  public List<ParsedStockPrice> parseAll(String message) {
+    if (message == null || message.isBlank() || message.startsWith("{")) {
+      return List.of();
+    }
+
+    String[] parts = message.split("\\|", 4);
+    if (parts.length < 4 || !DOMESTIC_STOCK_REALTIME_TR_ID.equals(parts[1])) {
+      return List.of();
+    }
+
+    if ("1".equals(parts[0])) {
+      log.warn("암호화된 한국투자증권 실시간 체결가 메시지는 처리하지 않습니다.");
+      return List.of();
+    }
+
+    String[] fields = parts[3].split("\\^", -1);
+    if (fields.length <= CHANGE_RATE_FIELD) {
+      log.warn("한국투자증권 실시간 체결가 메시지 필드 수가 부족합니다. count={}", fields.length);
+      return List.of();
+    }
+
+    int dataCount = parseDataCount(parts[2]);
+    List<ParsedStockPrice> prices = new ArrayList<>();
+    for (int index = 0; index < dataCount; index++) {
+      int offset = index * RESPONSE_FIELD_COUNT;
+      if (fields.length <= offset + CHANGE_RATE_FIELD) {
+        log.warn("한국투자증권 실시간 체결가 메시지 항목 필드 수가 부족합니다. item={}, count={}", index, fields.length);
+        break;
+      }
+      prices.add(toParsedStockPrice(fields, offset));
+    }
+
+    return prices;
+  }
+
+  private ParsedStockPrice toParsedStockPrice(String[] fields, int offset) {
+    String signCode = fields[offset + CHANGE_SIGN_FIELD];
+    return new ParsedStockPrice(
+        fields[offset + TICKER_FIELD],
+        parseDecimal(fields[offset + CURRENT_PRICE_FIELD]).abs().longValue(),
+        applySign(parseDecimal(fields[offset + CHANGE_AMOUNT_FIELD]), signCode).longValue(),
+        applySign(parseDecimal(fields[offset + CHANGE_RATE_FIELD]), signCode),
+        signCode,
+        StockPriceDirection.fromSignCode(signCode),
+        parseTimestamp(
+            fieldValue(fields, offset + BUSINESS_DATE_FIELD),
+            fieldValue(fields, offset + TRADE_TIME_FIELD)));
+  }
+
+  private int parseDataCount(String dataCount) {
+    try {
+      return Integer.parseInt(dataCount);
+    } catch (NumberFormatException e) {
+      return 1;
+    }
+  }
+
+  private String fieldValue(String[] fields, int index) {
+    if (index >= fields.length) {
+      return null;
+    }
+    return fields[index];
+  }
+
+  private BigDecimal parseDecimal(String value) {
+    if (value == null || value.isBlank()) {
+      return BigDecimal.ZERO;
+    }
+    try {
+      return new BigDecimal(value.trim().replace(",", ""));
+    } catch (NumberFormatException e) {
+      log.warn("한국투자증권 실시간 체결가 메시지의 숫자 형식이 올바르지 않습니다. value={}", value);
+      return BigDecimal.ZERO;
+    }
+  }
+
+  private BigDecimal applySign(BigDecimal value, String signCode) {
+    StockPriceDirection direction = StockPriceDirection.fromSignCode(signCode);
+    return switch (direction) {
+      case DOWN -> value.abs().negate();
+      case FLAT -> BigDecimal.ZERO;
+      case UP, UNKNOWN -> value.abs();
+    };
+  }
+
+  private LocalDateTime parseTimestamp(String kisDate, String kisTime) {
+    LocalDate date = parseDate(kisDate);
+    if (kisTime == null || kisTime.isBlank()) {
+      return LocalDateTime.now(KOREA_ZONE).withNano(0);
+    }
+
+    try {
+      LocalDateTime now = LocalDateTime.now(KOREA_ZONE).withNano(0);
+      LocalDateTime timestamp =
+          LocalDateTime.of(date, LocalTime.parse(kisTime, KIS_TIME_FORMATTER));
+      if (timestamp.isAfter(now.plus(FUTURE_TIMESTAMP_TOLERANCE))) {
+        return timestamp.minusDays(1);
+      }
+      return timestamp;
+    } catch (DateTimeParseException e) {
+      return LocalDateTime.now(KOREA_ZONE).withNano(0);
+    }
+  }
+
+  private LocalDate parseDate(String kisDate) {
+    if (kisDate == null || kisDate.isBlank()) {
+      return LocalDate.now(KOREA_ZONE);
+    }
+
+    try {
+      return LocalDate.parse(kisDate, KIS_DATE_FORMATTER);
+    } catch (DateTimeParseException e) {
+      return LocalDate.now(KOREA_ZONE);
+    }
+  }
+
+  public record ParsedStockPrice(
+      String ticker,
+      Long currentPriceKrw,
+      Long changeAmountKrw,
+      BigDecimal changeRate,
+      String signCode,
+      StockPriceDirection direction,
+      LocalDateTime updatedAt) {}
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockSummaryRedisService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockSummaryRedisService.java
@@ -5,6 +5,7 @@ import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
 import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -42,6 +43,6 @@ public class StockSummaryRedisService {
   }
 
   private String redisKey(String ticker) {
-    return SUMMARY_KEY_PREFIX + ticker.trim().toUpperCase();
+    return SUMMARY_KEY_PREFIX + ticker.trim().toUpperCase(Locale.ROOT);
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockSummaryRedisService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockSummaryRedisService.java
@@ -1,0 +1,47 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StockSummaryRedisService {
+
+  private static final String SUMMARY_KEY_PREFIX = "stock:summary:";
+
+  private final StringRedisTemplate stringRedisTemplate;
+  private final ObjectMapper objectMapper;
+
+  public void save(StockResDTO.Summary summary) {
+    try {
+      stringRedisTemplate
+          .opsForValue()
+          .set(redisKey(summary.getTicker()), objectMapper.writeValueAsString(summary));
+    } catch (JsonProcessingException e) {
+      throw new StockException(StockErrorCode.STOCK_SUMMARY_CACHE_SERIALIZE_FAILED, e);
+    }
+  }
+
+  public StockResDTO.Summary find(String ticker) {
+    String json = stringRedisTemplate.opsForValue().get(redisKey(ticker));
+    if (json == null || json.isBlank()) {
+      return null;
+    }
+
+    try {
+      return objectMapper.readValue(json, StockResDTO.Summary.class);
+    } catch (JsonProcessingException e) {
+      throw new StockException(StockErrorCode.STOCK_SUMMARY_CACHE_DESERIALIZE_FAILED, e);
+    }
+  }
+
+  private String redisKey(String ticker) {
+    return SUMMARY_KEY_PREFIX + ticker.trim().toUpperCase();
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockChartQueryService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockChartQueryService.java
@@ -1,0 +1,8 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockChartResDTO;
+
+public interface StockChartQueryService {
+
+  StockChartResDTO.Chart getChart(String ticker, String range, String type);
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockChartQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockChartQueryServiceImpl.java
@@ -1,0 +1,77 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockChartResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartRange;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartType;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import com.example.elephantfinancelab_be.domain.stocks.repository.StockRepository;
+import com.example.elephantfinancelab_be.domain.stocks.service.KisStockChartClient;
+import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceWebSocketClient;
+import com.example.elephantfinancelab_be.domain.stocks.service.StockChartRedisService;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StockChartQueryServiceImpl implements StockChartQueryService {
+
+  private static final String CURRENCY_KRW = "KRW";
+
+  private final StockRepository stockRepository;
+  private final StockChartRedisService stockChartRedisService;
+  private final KisStockChartClient kisStockChartClient;
+  private final KisStockPriceWebSocketClient kisStockPriceWebSocketClient;
+
+  @Override
+  public StockChartResDTO.Chart getChart(String ticker, String range, String type) {
+    StockChartRange chartRange = StockChartRange.from(range);
+    StockChartType chartType = StockChartType.from(type);
+    Stock stock =
+        stockRepository
+            .findByTicker(normalizeTicker(ticker))
+            .orElseThrow(() -> new StockException(StockErrorCode.STOCK_NOT_FOUND));
+
+    StockChartResDTO.Chart cachedChart =
+        stockChartRedisService.find(stock.getTicker(), chartRange, chartType);
+    if (cachedChart != null) {
+      subscribeRealtimeIfNeeded(stock.getTicker(), chartRange);
+      log.info("종목 차트 캐시 조회 성공. ticker={}, range={}, type={}", stock.getTicker(), range, type);
+      return cachedChart;
+    }
+
+    List<StockChartResDTO.DataPoint> dataPoints =
+        kisStockChartClient.fetchChart(stock.getTicker(), chartRange);
+    StockChartResDTO.Chart chart =
+        new StockChartResDTO.Chart(
+            stock.getTicker(),
+            chartRange.getValue(),
+            chartType,
+            chartRange.getInterval(),
+            CURRENCY_KRW,
+            dataPoints);
+    stockChartRedisService.save(chart);
+    subscribeRealtimeIfNeeded(stock.getTicker(), chartRange);
+    return chart;
+  }
+
+  private void subscribeRealtimeIfNeeded(String ticker, StockChartRange range) {
+    if (range == StockChartRange.ONE_DAY) {
+      kisStockPriceWebSocketClient.subscribe(ticker);
+    }
+  }
+
+  private String normalizeTicker(String ticker) {
+    if (ticker == null || ticker.isBlank()) {
+      throw new StockException(StockErrorCode.STOCK_NOT_FOUND);
+    }
+    return ticker.trim().toUpperCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryService.java
@@ -1,0 +1,8 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
+
+public interface StockQueryService {
+
+  StockResDTO.Summary getSummary(String ticker);
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImpl.java
@@ -1,0 +1,53 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import com.example.elephantfinancelab_be.domain.stocks.repository.StockRepository;
+import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceClient;
+import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceWebSocketClient;
+import com.example.elephantfinancelab_be.domain.stocks.service.StockSummaryRedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StockQueryServiceImpl implements StockQueryService {
+
+  private final StockRepository stockRepository;
+  private final StockSummaryRedisService stockSummaryRedisService;
+  private final KisStockPriceClient kisStockPriceClient;
+  private final KisStockPriceWebSocketClient kisStockPriceWebSocketClient;
+
+  @Override
+  public StockResDTO.Summary getSummary(String ticker) {
+    Stock stock =
+        stockRepository
+            .findByTickerIgnoreCase(normalizeTicker(ticker))
+            .orElseThrow(() -> new StockException(StockErrorCode.STOCK_NOT_FOUND));
+
+    StockResDTO.Summary cachedSummary = stockSummaryRedisService.find(stock.getTicker());
+    if (cachedSummary != null) {
+      kisStockPriceWebSocketClient.subscribe(stock.getTicker());
+      log.info("종목 요약 캐시 조회 성공. ticker={}", stock.getTicker());
+      return cachedSummary;
+    }
+
+    StockResDTO.Summary summary = kisStockPriceClient.fetchSummary(stock);
+    stockSummaryRedisService.save(summary);
+    kisStockPriceWebSocketClient.subscribe(stock.getTicker());
+    return summary;
+  }
+
+  private String normalizeTicker(String ticker) {
+    if (ticker == null || ticker.isBlank()) {
+      throw new StockException(StockErrorCode.STOCK_NOT_FOUND);
+    }
+    return ticker.trim().toUpperCase();
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.elephantfinancelab_be.domain.stocks.repository.StockRepositor
 import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceClient;
 import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceWebSocketClient;
 import com.example.elephantfinancelab_be.domain.stocks.service.StockSummaryRedisService;
+import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,7 @@ public class StockQueryServiceImpl implements StockQueryService {
   public StockResDTO.Summary getSummary(String ticker) {
     Stock stock =
         stockRepository
-            .findByTickerIgnoreCase(normalizeTicker(ticker))
+            .findByTicker(normalizeTicker(ticker))
             .orElseThrow(() -> new StockException(StockErrorCode.STOCK_NOT_FOUND));
 
     StockResDTO.Summary cachedSummary = stockSummaryRedisService.find(stock.getTicker());
@@ -48,6 +49,6 @@ public class StockQueryServiceImpl implements StockQueryService {
     if (ticker == null || ticker.isBlank()) {
       throw new StockException(StockErrorCode.STOCK_NOT_FOUND);
     }
-    return ticker.trim().toUpperCase();
+    return ticker.trim().toUpperCase(Locale.ROOT);
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/elephantfinancelab_be/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -24,7 +24,11 @@ public class GeneralExceptionAdvice {
 
   @ExceptionHandler(GeneralException.class)
   public ResponseEntity<ApiResponse<Void>> handleGeneralException(GeneralException ex) {
-    log.warn("Handled GeneralException: {}", ex.getMessage());
+    log.warn(
+        "code={}, message={}, detail={}",
+        ex.getCode().getCode(),
+        ex.getCode().getMessage(),
+        ex.getMessage());
     log.debug("GeneralException detail", ex);
     return ResponseEntity.status(ex.getCode().getStatus())
         .body(ApiResponse.onFailure(ex.getCode(), null));
@@ -57,30 +61,35 @@ public class GeneralExceptionAdvice {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(
       HttpMessageNotReadableException ex) {
-    log.warn("Malformed request body: {}", ex.getMessage());
     BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
+    log.warn("code={}, message={}, detail={}", code.getCode(), code.getMessage(), ex.getMessage());
     return ResponseEntity.status(code.getStatus()).body(ApiResponse.onFailure(code, null));
   }
 
   @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
   public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentOrState(RuntimeException ex) {
-    log.warn("{}: {}", ex.getClass().getSimpleName(), ex.getMessage());
     BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
+    log.warn(
+        "code={}, message={}, exception={}, detail={}",
+        code.getCode(),
+        code.getMessage(),
+        ex.getClass().getSimpleName(),
+        ex.getMessage());
     return ResponseEntity.status(code.getStatus()).body(ApiResponse.onFailure(code, null));
   }
 
   @ExceptionHandler(AuthenticationException.class)
   public ResponseEntity<ApiResponse<Void>> handleAuthenticationException(
       AuthenticationException ex) {
-    log.warn("Authentication failed: {}", ex.getMessage());
     BaseErrorCode code = GeneralErrorCode.UNAUTHORIZED;
+    log.warn("code={}, message={}, detail={}", code.getCode(), code.getMessage(), ex.getMessage());
     return ResponseEntity.status(code.getStatus()).body(ApiResponse.onFailure(code, null));
   }
 
   @ExceptionHandler(AccessDeniedException.class)
   public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException ex) {
-    log.warn("Access denied: {}", ex.getMessage());
     BaseErrorCode code = GeneralErrorCode.FORBIDDEN;
+    log.warn("code={}, message={}, detail={}", code.getCode(), code.getMessage(), ex.getMessage());
     return ResponseEntity.status(code.getStatus()).body(ApiResponse.onFailure(code, null));
   }
 

--- a/src/main/java/com/example/elephantfinancelab_be/global/bootstrap/DevDataLoader.java
+++ b/src/main/java/com/example/elephantfinancelab_be/global/bootstrap/DevDataLoader.java
@@ -1,5 +1,7 @@
 package com.example.elephantfinancelab_be.global.bootstrap;
 
+import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.repository.StockRepository;
 import com.example.elephantfinancelab_be.domain.terms.entity.TermsType;
 import com.example.elephantfinancelab_be.domain.terms.entity.UserTermsAgreement;
 import com.example.elephantfinancelab_be.domain.terms.repository.UserTermsAgreementRepository;
@@ -8,6 +10,7 @@ import com.example.elephantfinancelab_be.domain.user.entity.Provider;
 import com.example.elephantfinancelab_be.domain.user.entity.User;
 import com.example.elephantfinancelab_be.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
@@ -26,9 +29,12 @@ public class DevDataLoader implements ApplicationRunner {
 
   private final UserRepository userRepository;
   private final UserTermsAgreementRepository userTermsAgreementRepository;
+  private final StockRepository stockRepository;
 
   @Override
   public void run(ApplicationArguments args) {
+    seedStocksIfMissing();
+
     User user = userRepository.findById(DEV_USER_ID).orElse(null);
     if (user == null) {
       if (userRepository.count() > 0) {
@@ -72,5 +78,20 @@ public class DevDataLoader implements ApplicationRunner {
               .agreedAt(now)
               .build());
     }
+  }
+
+  private void seedStocksIfMissing() {
+    if (stockRepository.count() > 0) {
+      return;
+    }
+
+    stockRepository.saveAll(
+        List.of(
+            Stock.builder().ticker("005930").name("삼성전자").build(),
+            Stock.builder().ticker("000660").name("SK하이닉스").build(),
+            Stock.builder().ticker("035420").name("NAVER").build(),
+            Stock.builder().ticker("035720").name("카카오").build(),
+            Stock.builder().ticker("005380").name("현대차").build(),
+            Stock.builder().ticker("373220").name("LG에너지솔루션").build()));
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/global/config/HttpClientConfig.java
+++ b/src/main/java/com/example/elephantfinancelab_be/global/config/HttpClientConfig.java
@@ -4,6 +4,7 @@ import java.net.http.HttpClient;
 import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class HttpClientConfig {
@@ -11,5 +12,10 @@ public class HttpClientConfig {
   @Bean
   public HttpClient httpClient() {
     return HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+  }
+
+  @Bean
+  public WebClient.Builder webClientBuilder() {
+    return WebClient.builder();
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/elephantfinancelab_be/global/config/SecurityConfig.java
@@ -50,7 +50,10 @@ public class SecurityConfig {
     "/api/auth/**",
     "/api/chart/market",
     "/api/chart/ranking",
+    "/api/stocks/**",
     "/api/auth/login/**",
+    "/ws",
+    "/ws/**",
   };
 
   private void writeApiFailure(HttpServletResponse response, BaseErrorCode errorCode)

--- a/src/main/java/com/example/elephantfinancelab_be/global/config/WebSocketConfig.java
+++ b/src/main/java/com/example/elephantfinancelab_be/global/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.example.elephantfinancelab_be.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    registry.enableSimpleBroker("/topic");
+    registry.setApplicationDestinationPrefixes("/app");
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
+  }
+}

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockPriceDirectionTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockPriceDirectionTest.java
@@ -1,0 +1,13 @@
+package com.example.elephantfinancelab_be.domain.stocks.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class StockPriceDirectionTest {
+
+  @Test
+  void fromSignCodeReturnsUnknownWhenSignCodeIsNull() {
+    assertThat(StockPriceDirection.fromSignCode(null)).isEqualTo(StockPriceDirection.UNKNOWN);
+  }
+}

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParserTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParserTest.java
@@ -1,0 +1,78 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockPriceDirection;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class StockPriceRealtimeParserTest {
+
+  private final StockPriceRealtimeParser parser = new StockPriceRealtimeParser();
+
+  @Test
+  void parseKisRealtimeStockPriceMessage() {
+    String message =
+        "0|H0STCNT0|001|" + item("005930", "093354", "71900", "5", "-100", "-0.14", "20230612");
+
+    StockPriceRealtimeParser.ParsedStockPrice result = parser.parse(message).orElseThrow();
+
+    assertThat(result.ticker()).isEqualTo("005930");
+    assertThat(result.currentPriceKrw()).isEqualTo(71900L);
+    assertThat(result.changeAmountKrw()).isEqualTo(-100L);
+    assertThat(result.changeRate()).isEqualByComparingTo(new BigDecimal("-0.14"));
+    assertThat(result.signCode()).isEqualTo("5");
+    assertThat(result.direction()).isEqualTo(StockPriceDirection.DOWN);
+    assertThat(result.updatedAt().toLocalDate().toString()).isEqualTo("2023-06-12");
+  }
+
+  @Test
+  void parseKisRealtimeStockPriceMessageWithUpSign() {
+    String message =
+        "0|H0STCNT0|001|" + item("000660", "143000", "180000", "2", "2500", "1.41", "20260513");
+
+    StockPriceRealtimeParser.ParsedStockPrice result = parser.parse(message).orElseThrow();
+
+    assertThat(result.changeAmountKrw()).isEqualTo(2500L);
+    assertThat(result.changeRate()).isEqualByComparingTo(new BigDecimal("1.41"));
+    assertThat(result.direction()).isEqualTo(StockPriceDirection.UP);
+  }
+
+  @Test
+  void parseMultipleKisRealtimeStockPriceMessages() {
+    String message =
+        "0|H0STCNT0|002|"
+            + item("005930", "093354", "71900", "5", "-100", "-0.14", "20230612")
+            + "^"
+            + item("000660", "143000", "180000", "2", "2500", "1.41", "20230612");
+
+    var result = parser.parseAll(message);
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).ticker()).isEqualTo("005930");
+    assertThat(result.get(1).ticker()).isEqualTo("000660");
+  }
+
+  private String item(
+      String ticker,
+      String tradeTime,
+      String currentPrice,
+      String signCode,
+      String changeAmount,
+      String changeRate,
+      String businessDate) {
+    String[] fields = new String[46];
+    for (int i = 0; i < fields.length; i++) {
+      fields[i] = "0";
+    }
+
+    fields[0] = ticker;
+    fields[1] = tradeTime;
+    fields[2] = currentPrice;
+    fields[3] = signCode;
+    fields[4] = changeAmount;
+    fields[5] = changeRate;
+    fields[33] = businessDate;
+    return String.join("^", fields);
+  }
+}


### PR DESCRIPTION
## 💡 Issue
- Close #36

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- 종목 차트 시계열 조회 API 추가
- KIS 차트 API를 WebClient 기반으로 호출
- Redis 캐싱 및 1D 실시간 차트 업데이트/STOMP push 구현

## 🛠️ Changes
- GET /api/stocks/{ticker}/chart?range={range}&type={type} API 추가
- 1D는 KIS 주식당일분봉조회, 1W/3M/1Y/5Y/ALL은 국내주식기간별시세 API 호출
- 차트 응답 DTO, range/type/interval enum 추가
- Redis 캐싱 추가: stock:chart:{ticker}:{range}:{type}
- range별 TTL 적용
- 기존 실시간 체결가 WebSocket 데이터를 재사용해 1D 차트 캐시 업데이트
- /topic/stocks/{ticker}/chart STOMP push 추가
- warning 로그에 에러코드 포함

## 📸 Screenshots
<img width="530" height="443" alt="스크린샷 2026-05-13 21 17 46" src="https://github.com/user-attachments/assets/f22b7db9-3b7a-4c5b-b506-38706a6414f2" />
<img width="530" height="443" alt="스크린샷 2026-05-13 21 17 50" src="https://github.com/user-attachments/assets/9b133b1c-39bd-48de-b931-bd9101046883" />


## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 주식 정보 및 차트 데이터 조회 API 추가
  * WebSocket을 통한 실시간 주가 및 차트 업데이트 지원
  * 다양한 차트 범위(1일, 1주, 3개월, 1년, 5년, 전체) 및 유형(라인, 캔들) 지원

* **개선사항**
  * 통합 에러 처리 및 구조화된 로깅 강화
  * Redis 캐싱을 통한 성능 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elephant-finance-lab/BE/pull/37)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->