### PR TITLE
[FEAT] 재무 제표 상세 조회 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
           KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
           KIS_APP_KEY: ${{ secrets.KIS_APP_KEY }}
           KIS_APP_SECRET: ${{ secrets.KIS_APP_SECRET }}
+          KIS_FINANCIAL_APP_KEY: ${{ secrets.KIS_FINANCIAL_APP_KEY }}
+          KIS_FINANCIAL_APP_SECRET: ${{ secrets.KIS_FINANCIAL_APP_SECRET }}
           KIS_BASE_URL: ${{ secrets.KIS_BASE_URL }}
           KIS_WS_URL: ${{ secrets.KIS_WS_URL }}
 

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisAccessTokenClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisAccessTokenClient.java
@@ -10,7 +10,11 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.HexFormat;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +29,8 @@ import org.springframework.stereotype.Component;
 public class KisAccessTokenClient {
 
   private static final String TOKEN_PATH = "/oauth2/tokenP";
-  private static final String TOKEN_REDIS_KEY = "kis:access-token";
-  private static final String TOKEN_LOCK_REDIS_KEY = "kis:access-token:lock";
+  private static final String TOKEN_REDIS_KEY_PREFIX = "kis:access-token:";
+  private static final String TOKEN_LOCK_REDIS_KEY_SUFFIX = ":lock";
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
   private static final Duration TOKEN_LOCK_TTL = Duration.ofSeconds(15);
   private static final Duration TOKEN_WAIT_TIMEOUT = Duration.ofSeconds(8);
@@ -38,28 +42,29 @@ public class KisAccessTokenClient {
   private final HttpClient httpClient;
 
   public String getAccessToken() {
-    String cachedToken = stringRedisTemplate.opsForValue().get(TOKEN_REDIS_KEY);
+    String tokenRedisKey = tokenRedisKey();
+    String cachedToken = stringRedisTemplate.opsForValue().get(tokenRedisKey);
     if (cachedToken != null && !cachedToken.isBlank()) {
       return cachedToken;
     }
 
     String lockValue = UUID.randomUUID().toString();
-    if (acquireTokenLock(lockValue)) {
+    if (acquireTokenLock(tokenRedisKey, lockValue)) {
       try {
-        String tokenAfterLock = stringRedisTemplate.opsForValue().get(TOKEN_REDIS_KEY);
+        String tokenAfterLock = stringRedisTemplate.opsForValue().get(tokenRedisKey);
         if (tokenAfterLock != null && !tokenAfterLock.isBlank()) {
           return tokenAfterLock;
         }
-        return issueAccessToken();
+        return issueAccessToken(tokenRedisKey);
       } finally {
-        releaseTokenLock(lockValue);
+        releaseTokenLock(tokenRedisKey, lockValue);
       }
     }
 
-    return waitForIssuedToken();
+    return waitForIssuedToken(tokenRedisKey);
   }
 
-  private String issueAccessToken() {
+  private String issueAccessToken(String tokenRedisKey) {
     try {
       HttpRequest request =
           HttpRequest.newBuilder()
@@ -89,7 +94,7 @@ public class KisAccessTokenClient {
 
       long expiresIn = root.path("expires_in").asLong(86_400);
       Duration ttl = Duration.ofSeconds(Math.max(60, expiresIn - 60));
-      stringRedisTemplate.opsForValue().set(TOKEN_REDIS_KEY, accessToken, ttl);
+      stringRedisTemplate.opsForValue().set(tokenRedisKey, accessToken, ttl);
       log.info("한국투자증권 접근 토큰 발급 완료");
       return accessToken;
     } catch (IOException e) {
@@ -100,25 +105,26 @@ public class KisAccessTokenClient {
     }
   }
 
-  private boolean acquireTokenLock(String lockValue) {
+  private boolean acquireTokenLock(String tokenRedisKey, String lockValue) {
     Boolean locked =
         stringRedisTemplate
             .opsForValue()
-            .setIfAbsent(TOKEN_LOCK_REDIS_KEY, lockValue, TOKEN_LOCK_TTL);
+            .setIfAbsent(tokenLockRedisKey(tokenRedisKey), lockValue, TOKEN_LOCK_TTL);
     return Boolean.TRUE.equals(locked);
   }
 
-  private void releaseTokenLock(String lockValue) {
-    String currentLockValue = stringRedisTemplate.opsForValue().get(TOKEN_LOCK_REDIS_KEY);
+  private void releaseTokenLock(String tokenRedisKey, String lockValue) {
+    String currentLockValue =
+        stringRedisTemplate.opsForValue().get(tokenLockRedisKey(tokenRedisKey));
     if (lockValue.equals(currentLockValue)) {
-      stringRedisTemplate.delete(TOKEN_LOCK_REDIS_KEY);
+      stringRedisTemplate.delete(tokenLockRedisKey(tokenRedisKey));
     }
   }
 
-  private String waitForIssuedToken() {
+  private String waitForIssuedToken(String tokenRedisKey) {
     long deadline = System.nanoTime() + TOKEN_WAIT_TIMEOUT.toNanos();
     while (System.nanoTime() < deadline) {
-      String token = stringRedisTemplate.opsForValue().get(TOKEN_REDIS_KEY);
+      String token = stringRedisTemplate.opsForValue().get(tokenRedisKey);
       if (token != null && !token.isBlank()) {
         return token;
       }
@@ -139,10 +145,7 @@ public class KisAccessTokenClient {
   }
 
   private URI tokenUri() {
-    String baseUrl = kisProperties.getBaseUrl();
-    String normalizedBaseUrl =
-        baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
-    return URI.create(normalizedBaseUrl + TOKEN_PATH);
+    return URI.create(normalizedBaseUrl() + TOKEN_PATH);
   }
 
   private String requestBody() throws IOException {
@@ -154,5 +157,31 @@ public class KisAccessTokenClient {
             kisProperties.getAppKey(),
             "appsecret",
             kisProperties.getAppSecret()));
+  }
+
+  private String tokenRedisKey() {
+    return TOKEN_REDIS_KEY_PREFIX + keyFingerprint();
+  }
+
+  private String tokenLockRedisKey(String tokenRedisKey) {
+    return tokenRedisKey + TOKEN_LOCK_REDIS_KEY_SUFFIX;
+  }
+
+  private String keyFingerprint() {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash =
+          digest.digest(
+              (normalizedBaseUrl() + ":" + kisProperties.getAppKey())
+                  .getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(hash, 0, 8);
+    } catch (NoSuchAlgorithmException e) {
+      throw new ChartException(ChartErrorCode.KIS_ACCESS_TOKEN_FAILED, e);
+    }
+  }
+
+  private String normalizedBaseUrl() {
+    String baseUrl = kisProperties.getBaseUrl();
+    return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisAccessTokenClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisAccessTokenClient.java
@@ -15,11 +15,13 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 
@@ -35,6 +37,12 @@ public class KisAccessTokenClient {
   private static final Duration TOKEN_LOCK_TTL = Duration.ofSeconds(15);
   private static final Duration TOKEN_WAIT_TIMEOUT = Duration.ofSeconds(8);
   private static final Duration TOKEN_WAIT_INTERVAL = Duration.ofMillis(100);
+  private static final DefaultRedisScript<Long> RELEASE_LOCK_SCRIPT =
+      new DefaultRedisScript<>(
+          "if redis.call('get', KEYS[1]) == ARGV[1] then "
+              + "return redis.call('del', KEYS[1]) "
+              + "else return 0 end",
+          Long.class);
 
   private final KisProperties kisProperties;
   private final ObjectMapper objectMapper;
@@ -42,7 +50,16 @@ public class KisAccessTokenClient {
   private final HttpClient httpClient;
 
   public String getAccessToken() {
-    String tokenRedisKey = tokenRedisKey();
+    return getAccessToken(
+        kisProperties.getAppKey(), kisProperties.getAppSecret(), kisProperties.getBaseUrl());
+  }
+
+  public String getAccessToken(String appKey, String appSecret) {
+    return getAccessToken(appKey, appSecret, kisProperties.getBaseUrl());
+  }
+
+  public String getAccessToken(String appKey, String appSecret, String baseUrl) {
+    String tokenRedisKey = tokenRedisKey(appKey, baseUrl);
     String cachedToken = stringRedisTemplate.opsForValue().get(tokenRedisKey);
     if (cachedToken != null && !cachedToken.isBlank()) {
       return cachedToken;
@@ -55,7 +72,7 @@ public class KisAccessTokenClient {
         if (tokenAfterLock != null && !tokenAfterLock.isBlank()) {
           return tokenAfterLock;
         }
-        return issueAccessToken(tokenRedisKey);
+        return issueAccessToken(tokenRedisKey, appKey, appSecret, baseUrl);
       } finally {
         releaseTokenLock(tokenRedisKey, lockValue);
       }
@@ -64,14 +81,15 @@ public class KisAccessTokenClient {
     return waitForIssuedToken(tokenRedisKey);
   }
 
-  private String issueAccessToken(String tokenRedisKey) {
+  private String issueAccessToken(
+      String tokenRedisKey, String appKey, String appSecret, String baseUrl) {
     try {
       HttpRequest request =
           HttpRequest.newBuilder()
-              .uri(tokenUri())
+              .uri(tokenUri(baseUrl))
               .timeout(REQUEST_TIMEOUT)
               .header("content-type", MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8")
-              .POST(HttpRequest.BodyPublishers.ofString(requestBody()))
+              .POST(HttpRequest.BodyPublishers.ofString(requestBody(appKey, appSecret)))
               .build();
 
       HttpResponse<String> response =
@@ -79,10 +97,13 @@ public class KisAccessTokenClient {
 
       if (response.statusCode() < 200 || response.statusCode() >= 300) {
         log.warn(
-            "code={}, message={}, status={}",
+            "code={}, message={}, status={}, baseUrl={}, appKey={}, responseBody={}",
             ChartErrorCode.KIS_ACCESS_TOKEN_FAILED.getCode(),
             ChartErrorCode.KIS_ACCESS_TOKEN_FAILED.getMessage(),
-            response.statusCode());
+            response.statusCode(),
+            normalizedBaseUrl(baseUrl),
+            maskedAppKey(appKey),
+            response.body());
         throw new ChartException(ChartErrorCode.KIS_ACCESS_TOKEN_FAILED);
       }
 
@@ -114,11 +135,8 @@ public class KisAccessTokenClient {
   }
 
   private void releaseTokenLock(String tokenRedisKey, String lockValue) {
-    String currentLockValue =
-        stringRedisTemplate.opsForValue().get(tokenLockRedisKey(tokenRedisKey));
-    if (lockValue.equals(currentLockValue)) {
-      stringRedisTemplate.delete(tokenLockRedisKey(tokenRedisKey));
-    }
+    stringRedisTemplate.execute(
+        RELEASE_LOCK_SCRIPT, List.of(tokenLockRedisKey(tokenRedisKey)), lockValue);
   }
 
   private String waitForIssuedToken(String tokenRedisKey) {
@@ -144,44 +162,46 @@ public class KisAccessTokenClient {
     throw new ChartException(ChartErrorCode.KIS_ACCESS_TOKEN_FAILED);
   }
 
-  private URI tokenUri() {
-    return URI.create(normalizedBaseUrl() + TOKEN_PATH);
+  private URI tokenUri(String baseUrl) {
+    return URI.create(normalizedBaseUrl(baseUrl) + TOKEN_PATH);
   }
 
-  private String requestBody() throws IOException {
+  private String requestBody(String appKey, String appSecret) throws IOException {
     return objectMapper.writeValueAsString(
-        Map.of(
-            "grant_type",
-            "client_credentials",
-            "appkey",
-            kisProperties.getAppKey(),
-            "appsecret",
-            kisProperties.getAppSecret()));
+        Map.of("grant_type", "client_credentials", "appkey", appKey, "appsecret", appSecret));
   }
 
-  private String tokenRedisKey() {
-    return TOKEN_REDIS_KEY_PREFIX + keyFingerprint();
+  private String tokenRedisKey(String appKey, String baseUrl) {
+    return TOKEN_REDIS_KEY_PREFIX + keyFingerprint(appKey, baseUrl);
   }
 
   private String tokenLockRedisKey(String tokenRedisKey) {
     return tokenRedisKey + TOKEN_LOCK_REDIS_KEY_SUFFIX;
   }
 
-  private String keyFingerprint() {
+  private String keyFingerprint(String appKey, String baseUrl) {
     try {
       MessageDigest digest = MessageDigest.getInstance("SHA-256");
       byte[] hash =
           digest.digest(
-              (normalizedBaseUrl() + ":" + kisProperties.getAppKey())
-                  .getBytes(StandardCharsets.UTF_8));
+              (normalizedBaseUrl(baseUrl) + ":" + appKey).getBytes(StandardCharsets.UTF_8));
       return HexFormat.of().formatHex(hash, 0, 8);
     } catch (NoSuchAlgorithmException e) {
       throw new ChartException(ChartErrorCode.KIS_ACCESS_TOKEN_FAILED, e);
     }
   }
 
-  private String normalizedBaseUrl() {
-    String baseUrl = kisProperties.getBaseUrl();
+  private String normalizedBaseUrl(String baseUrl) {
     return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+  }
+
+  private String maskedAppKey(String appKey) {
+    if (appKey == null || appKey.isBlank()) {
+      return "blank";
+    }
+    if (appKey.length() <= 8) {
+      return "****";
+    }
+    return appKey.substring(0, 4) + "****" + appKey.substring(appKey.length() - 4);
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/controller/StockController.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/controller/StockController.java
@@ -2,9 +2,11 @@ package com.example.elephantfinancelab_be.domain.stocks.controller;
 
 import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockChartResDTO;
 import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockDailyPriceResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockFinancialResDTO;
 import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
 import com.example.elephantfinancelab_be.domain.stocks.service.query.StockChartQueryService;
 import com.example.elephantfinancelab_be.domain.stocks.service.query.StockDailyPriceQueryService;
+import com.example.elephantfinancelab_be.domain.stocks.service.query.StockFinancialQueryService;
 import com.example.elephantfinancelab_be.domain.stocks.service.query.StockQueryService;
 import com.example.elephantfinancelab_be.global.apiPayload.ApiResponse;
 import com.example.elephantfinancelab_be.global.apiPayload.code.GeneralSuccessCode;
@@ -28,6 +30,7 @@ public class StockController {
   private final StockQueryService stockQueryService;
   private final StockChartQueryService stockChartQueryService;
   private final StockDailyPriceQueryService stockDailyPriceQueryService;
+  private final StockFinancialQueryService stockFinancialQueryService;
 
   @Operation(summary = "종목 상세 상단 조회", description = "국내주식 종목명, 현재가, 전일 대비 정보를 조회합니다.")
   @GetMapping("/{ticker}/summary")
@@ -54,6 +57,19 @@ public class StockController {
   public ResponseEntity<ApiResponse<StockDailyPriceResDTO.DailyPrices>> getDailyPrices(
       @Parameter(description = "종목코드. 예: 005930") @PathVariable String ticker) {
     StockDailyPriceResDTO.DailyPrices result = stockDailyPriceQueryService.getDailyPrices(ticker);
+    return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
+        .body(ApiResponse.of(GeneralSuccessCode.OK, result));
+  }
+
+  @Operation(summary = "종목 재무제표 조회", description = "손익계산서, 재무상태표, 재무비율 표 데이터를 조회합니다.")
+  @GetMapping("/{ticker}/financial")
+  public ResponseEntity<ApiResponse<StockFinancialResDTO.Financial>> getFinancial(
+      @Parameter(description = "종목코드. 예: 005930") @PathVariable String ticker,
+      @Parameter(description = "INCOME, BALANCE, RATIO") @RequestParam String statement,
+      @Parameter(description = "QUARTER, YEAR. 기본값 QUARTER") @RequestParam(defaultValue = "QUARTER")
+          String period) {
+    StockFinancialResDTO.Financial result =
+        stockFinancialQueryService.getFinancial(ticker, statement, period);
     return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
         .body(ApiResponse.of(GeneralSuccessCode.OK, result));
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/dto/res/StockFinancialResDTO.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/dto/res/StockFinancialResDTO.java
@@ -1,0 +1,19 @@
+package com.example.elephantfinancelab_be.domain.stocks.dto.res;
+
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialPeriod;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialStatement;
+import java.util.List;
+
+public class StockFinancialResDTO {
+
+  public record Financial(
+      String ticker,
+      String nameKor,
+      StockFinancialStatement statement,
+      StockFinancialPeriod period,
+      String unit,
+      List<String> columns,
+      List<Row> rows) {}
+
+  public record Row(String label, List<String> values) {}
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/Stock.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/Stock.java
@@ -37,8 +37,10 @@ public class Stock extends BaseEntity {
   @PrePersist
   @PreUpdate
   private void normalizeTicker() {
-    if (ticker != null) {
-      ticker = ticker.trim().toUpperCase(Locale.ROOT);
+    String normalizedTicker = ticker == null ? null : ticker.trim().toUpperCase(Locale.ROOT);
+    if (normalizedTicker == null || normalizedTicker.isBlank()) {
+      throw new IllegalArgumentException("ticker must not be blank");
     }
+    ticker = normalizedTicker;
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockFinancialApiType.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockFinancialApiType.java
@@ -1,0 +1,16 @@
+package com.example.elephantfinancelab_be.domain.stocks.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockFinancialApiType {
+  INCOME("/uapi/domestic-stock/v1/finance/income-statement", "FHKST66430200"),
+  BALANCE("/uapi/domestic-stock/v1/finance/balance-sheet", "FHKST66430100"),
+  FINANCIAL_RATIO("/uapi/domestic-stock/v1/finance/financial-ratio", "FHKST66430300"),
+  PROFIT_RATIO("/uapi/domestic-stock/v1/finance/profit-ratio", "FHKST66430400");
+
+  private final String path;
+  private final String trId;
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockFinancialPeriod.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockFinancialPeriod.java
@@ -1,0 +1,28 @@
+package com.example.elephantfinancelab_be.domain.stocks.entity;
+
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import java.util.Locale;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockFinancialPeriod {
+  QUARTER("1"),
+  YEAR("0");
+
+  private final String kisDivClsCode;
+
+  public static StockFinancialPeriod from(String value) {
+    if (value == null || value.isBlank()) {
+      return QUARTER;
+    }
+
+    try {
+      return StockFinancialPeriod.valueOf(value.trim().toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new StockException(StockErrorCode.INVALID_STOCK_FINANCIAL_PERIOD);
+    }
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockFinancialStatement.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockFinancialStatement.java
@@ -1,0 +1,74 @@
+package com.example.elephantfinancelab_be.domain.stocks.entity;
+
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import java.util.List;
+import java.util.Locale;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockFinancialStatement {
+  INCOME(
+      "백만원",
+      List.of(
+          new Metric(StockFinancialApiType.INCOME, "매출액", "sale_account"),
+          new Metric(StockFinancialApiType.INCOME, "매출 원가", "sale_cost"),
+          new Metric(StockFinancialApiType.INCOME, "매출 총 이익", "sale_totl_prfi"),
+          new Metric(StockFinancialApiType.INCOME, "감가상각비", "depr_cost"),
+          new Metric(StockFinancialApiType.INCOME, "판매 및 관리비", "sell_mang"),
+          new Metric(StockFinancialApiType.INCOME, "영업 이익", "bsop_prti"),
+          new Metric(StockFinancialApiType.INCOME, "영업 외 수익", "bsop_non_ernn"),
+          new Metric(StockFinancialApiType.INCOME, "영업 외 비용", "bsop_non_expn"),
+          new Metric(StockFinancialApiType.INCOME, "경상 이익", "op_prfi"),
+          new Metric(StockFinancialApiType.INCOME, "특별 이익", "spec_prfi"),
+          new Metric(StockFinancialApiType.INCOME, "특별 손실", "spec_loss"),
+          new Metric(StockFinancialApiType.INCOME, "당기순이익", "thtr_ntin"))),
+  BALANCE(
+      "백만원",
+      List.of(
+          new Metric(StockFinancialApiType.BALANCE, "유동자산", "cras"),
+          new Metric(StockFinancialApiType.BALANCE, "고정자산", "fxas"),
+          new Metric(StockFinancialApiType.BALANCE, "자산총계", "total_aset"),
+          new Metric(StockFinancialApiType.BALANCE, "유동부채", "flow_lblt"),
+          new Metric(StockFinancialApiType.BALANCE, "고정부채", "fix_lblt"),
+          new Metric(StockFinancialApiType.BALANCE, "부채총계", "total_lblt"),
+          new Metric(StockFinancialApiType.BALANCE, "자본금", "cpfn"),
+          new Metric(StockFinancialApiType.BALANCE, "자본 잉여금", "cfp_surp"),
+          new Metric(StockFinancialApiType.BALANCE, "이익 잉여금", "prfi_surp"),
+          new Metric(StockFinancialApiType.BALANCE, "자본총계", "total_cptl"))),
+  RATIO(
+      "혼합",
+      List.of(
+          new Metric(StockFinancialApiType.FINANCIAL_RATIO, "매출액 증가율", "grs"),
+          new Metric(StockFinancialApiType.FINANCIAL_RATIO, "영업 이익 증가율", "bsop_prfi_inrt"),
+          new Metric(StockFinancialApiType.FINANCIAL_RATIO, "순이익 증가율", "ntin_inrt"),
+          new Metric(StockFinancialApiType.FINANCIAL_RATIO, "ROE", "roe_val"),
+          new Metric(StockFinancialApiType.FINANCIAL_RATIO, "EPS", "eps"),
+          new Metric(StockFinancialApiType.FINANCIAL_RATIO, "주당매출액", "sps"),
+          new Metric(StockFinancialApiType.FINANCIAL_RATIO, "BPS", "bps"),
+          new Metric(StockFinancialApiType.FINANCIAL_RATIO, "유보 비율", "rsrv_rate"),
+          new Metric(StockFinancialApiType.FINANCIAL_RATIO, "부채 비율", "lblt_rate"),
+          new Metric(StockFinancialApiType.PROFIT_RATIO, "총자본 순이익율", "cptl_ntin_rate"),
+          new Metric(StockFinancialApiType.PROFIT_RATIO, "자기자본 순이익율", "self_cptl_ntin_inrt"),
+          new Metric(StockFinancialApiType.PROFIT_RATIO, "매출액 순이익율", "sale_ntin_rate"),
+          new Metric(StockFinancialApiType.PROFIT_RATIO, "매출액 총이익율", "sale_totl_rate")));
+
+  private final String unit;
+  private final List<Metric> metrics;
+
+  public static StockFinancialStatement from(String value) {
+    if (value == null || value.isBlank()) {
+      throw new StockException(StockErrorCode.INVALID_STOCK_FINANCIAL_STATEMENT);
+    }
+
+    try {
+      return StockFinancialStatement.valueOf(value.trim().toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new StockException(StockErrorCode.INVALID_STOCK_FINANCIAL_STATEMENT);
+    }
+  }
+
+  public record Metric(StockFinancialApiType apiType, String label, String fieldName) {}
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockFinancialStatement.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/entity/StockFinancialStatement.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum StockFinancialStatement {
   INCOME(
-      "백만원",
+      "억원",
       List.of(
           new Metric(StockFinancialApiType.INCOME, "매출액", "sale_account"),
           new Metric(StockFinancialApiType.INCOME, "매출 원가", "sale_cost"),
@@ -26,7 +26,7 @@ public enum StockFinancialStatement {
           new Metric(StockFinancialApiType.INCOME, "특별 손실", "spec_loss"),
           new Metric(StockFinancialApiType.INCOME, "당기순이익", "thtr_ntin"))),
   BALANCE(
-      "백만원",
+      "억원",
       List.of(
           new Metric(StockFinancialApiType.BALANCE, "유동자산", "cras"),
           new Metric(StockFinancialApiType.BALANCE, "고정자산", "fxas"),

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/exception/code/StockErrorCode.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/exception/code/StockErrorCode.java
@@ -11,6 +11,8 @@ public enum StockErrorCode implements BaseErrorCode {
   STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "STOCK404_01", "존재하지 않는 종목입니다."),
   INVALID_STOCK_CHART_RANGE(HttpStatus.BAD_REQUEST, "STOCK400_1", "지원하지 않는 차트 범위입니다."),
   INVALID_STOCK_CHART_TYPE(HttpStatus.BAD_REQUEST, "STOCK400_2", "지원하지 않는 차트 타입입니다."),
+  INVALID_STOCK_FINANCIAL_STATEMENT(HttpStatus.BAD_REQUEST, "STOCK400_3", "지원하지 않는 재무제표 타입입니다."),
+  INVALID_STOCK_FINANCIAL_PERIOD(HttpStatus.BAD_REQUEST, "STOCK400_4", "지원하지 않는 재무제표 기간입니다."),
   STOCK_SUMMARY_CACHE_SERIALIZE_FAILED(
       HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_1", "종목 요약 캐시 저장에 실패했습니다."),
   STOCK_SUMMARY_CACHE_DESERIALIZE_FAILED(
@@ -27,6 +29,10 @@ public enum StockErrorCode implements BaseErrorCode {
       HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_7", "종목 차트 실시간 업데이트에 실패했습니다."),
   STOCK_CHART_PUSH_FAILED(
       HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_8", "종목 차트 실시간 push 전송에 실패했습니다."),
+  STOCK_FINANCIAL_CACHE_SERIALIZE_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_9", "종목 재무제표 캐시 저장에 실패했습니다."),
+  STOCK_FINANCIAL_CACHE_DESERIALIZE_FAILED(
+      HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_10", "종목 재무제표 캐시 조회에 실패했습니다."),
   KIS_STOCK_PRICE_API_FAILED(HttpStatus.BAD_GATEWAY, "STOCK502_1", "한국투자증권 현재가 조회에 실패했습니다."),
   KIS_STOCK_PRICE_WEBSOCKET_FAILED(
       HttpStatus.BAD_GATEWAY, "STOCK502_2", "한국투자증권 실시간 체결가 구독에 실패했습니다."),
@@ -41,6 +47,9 @@ public enum StockErrorCode implements BaseErrorCode {
       HttpStatus.BAD_GATEWAY, "STOCK502_6", "한국투자증권 종목 차트 응답 파싱에 실패했습니다."),
   KIS_STOCK_DAILY_PRICE_RESPONSE_PARSE_FAILED(
       HttpStatus.BAD_GATEWAY, "STOCK502_8", "한국투자증권 일별 시세 응답 파싱에 실패했습니다."),
+  KIS_STOCK_FINANCIAL_API_FAILED(HttpStatus.BAD_GATEWAY, "STOCK502_9", "한국투자증권 재무제표 조회에 실패했습니다."),
+  KIS_STOCK_FINANCIAL_RESPONSE_PARSE_FAILED(
+      HttpStatus.BAD_GATEWAY, "STOCK502_10", "한국투자증권 재무제표 응답 파싱에 실패했습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/exception/code/StockErrorCode.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/exception/code/StockErrorCode.java
@@ -13,6 +13,7 @@ public enum StockErrorCode implements BaseErrorCode {
   INVALID_STOCK_CHART_TYPE(HttpStatus.BAD_REQUEST, "STOCK400_2", "지원하지 않는 차트 타입입니다."),
   INVALID_STOCK_FINANCIAL_STATEMENT(HttpStatus.BAD_REQUEST, "STOCK400_3", "지원하지 않는 재무제표 타입입니다."),
   INVALID_STOCK_FINANCIAL_PERIOD(HttpStatus.BAD_REQUEST, "STOCK400_4", "지원하지 않는 재무제표 기간입니다."),
+  INVALID_STOCK_TICKER(HttpStatus.BAD_REQUEST, "STOCK400_5", "종목코드는 필수입니다."),
   STOCK_SUMMARY_CACHE_SERIALIZE_FAILED(
       HttpStatus.INTERNAL_SERVER_ERROR, "STOCK500_1", "종목 요약 캐시 저장에 실패했습니다."),
   STOCK_SUMMARY_CACHE_DESERIALIZE_FAILED(

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockChartClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockChartClient.java
@@ -116,32 +116,34 @@ public class KisStockChartClient {
         ticker,
         TIME_ITEM_CHART_TR_ID,
         inputHour);
-    return webClient
-        .get()
-        .uri(
-            uriBuilder ->
-                uriBuilder
-                    .path(TIME_ITEM_CHART_PATH)
-                    .queryParam("FID_COND_MRKT_DIV_CODE", KRX_MARKET_DIV_CODE)
-                    .queryParam("FID_INPUT_ISCD", ticker)
-                    .queryParam("FID_INPUT_HOUR_1", inputHour)
-                    .queryParam("FID_PW_DATA_INCU_YN", "Y")
-                    .queryParam("FID_ETC_CLS_CODE", "")
-                    .build())
-        .headers(headers -> applyKisHeaders(headers, TIME_ITEM_CHART_TR_ID))
-        .retrieve()
-        .onStatus(
-            status -> status.isError(),
-            response ->
-                response
-                    .bodyToMono(String.class)
-                    .defaultIfEmpty("")
-                    .map(body -> stockChartApiException(response.statusCode().value(), body)))
-        .bodyToMono(String.class)
-        .map(this::readTree)
-        .timeout(REQUEST_TIMEOUT)
-        .onErrorMap(this::mapStockChartException)
-        .block();
+    JsonNode root =
+        webClient
+            .get()
+            .uri(
+                uriBuilder ->
+                    uriBuilder
+                        .path(TIME_ITEM_CHART_PATH)
+                        .queryParam("FID_COND_MRKT_DIV_CODE", KRX_MARKET_DIV_CODE)
+                        .queryParam("FID_INPUT_ISCD", ticker)
+                        .queryParam("FID_INPUT_HOUR_1", inputHour)
+                        .queryParam("FID_PW_DATA_INCU_YN", "Y")
+                        .queryParam("FID_ETC_CLS_CODE", "")
+                        .build())
+            .headers(headers -> applyKisHeaders(headers, TIME_ITEM_CHART_TR_ID))
+            .retrieve()
+            .onStatus(
+                status -> status.isError(),
+                response ->
+                    response
+                        .bodyToMono(String.class)
+                        .defaultIfEmpty("")
+                        .map(body -> stockChartApiException(response.statusCode().value(), body)))
+            .bodyToMono(String.class)
+            .map(this::readTree)
+            .timeout(REQUEST_TIMEOUT)
+            .onErrorMap(this::mapStockChartException)
+            .block();
+    return requireKisResponse(root, StockErrorCode.KIS_STOCK_CHART_API_FAILED);
   }
 
   private JsonNode fetchPeriodChart(String ticker, StockChartRange range) {
@@ -154,33 +156,35 @@ public class KisStockChartClient {
         startDate.format(KIS_DATE_FORMATTER),
         today.format(KIS_DATE_FORMATTER),
         range.getKisPeriodDivCode());
-    return webClient
-        .get()
-        .uri(
-            uriBuilder ->
-                uriBuilder
-                    .path(DAILY_ITEM_CHART_PATH)
-                    .queryParam("FID_COND_MRKT_DIV_CODE", KRX_MARKET_DIV_CODE)
-                    .queryParam("FID_INPUT_ISCD", ticker)
-                    .queryParam("FID_INPUT_DATE_1", startDate.format(KIS_DATE_FORMATTER))
-                    .queryParam("FID_INPUT_DATE_2", today.format(KIS_DATE_FORMATTER))
-                    .queryParam("FID_PERIOD_DIV_CODE", range.getKisPeriodDivCode())
-                    .queryParam("FID_ORG_ADJ_PRC", ADJUSTED_PRICE)
-                    .build())
-        .headers(headers -> applyKisHeaders(headers, DAILY_ITEM_CHART_TR_ID))
-        .retrieve()
-        .onStatus(
-            status -> status.isError(),
-            response ->
-                response
-                    .bodyToMono(String.class)
-                    .defaultIfEmpty("")
-                    .map(body -> stockChartApiException(response.statusCode().value(), body)))
-        .bodyToMono(String.class)
-        .map(this::readTree)
-        .timeout(REQUEST_TIMEOUT)
-        .onErrorMap(this::mapStockChartException)
-        .block();
+    JsonNode root =
+        webClient
+            .get()
+            .uri(
+                uriBuilder ->
+                    uriBuilder
+                        .path(DAILY_ITEM_CHART_PATH)
+                        .queryParam("FID_COND_MRKT_DIV_CODE", KRX_MARKET_DIV_CODE)
+                        .queryParam("FID_INPUT_ISCD", ticker)
+                        .queryParam("FID_INPUT_DATE_1", startDate.format(KIS_DATE_FORMATTER))
+                        .queryParam("FID_INPUT_DATE_2", today.format(KIS_DATE_FORMATTER))
+                        .queryParam("FID_PERIOD_DIV_CODE", range.getKisPeriodDivCode())
+                        .queryParam("FID_ORG_ADJ_PRC", ADJUSTED_PRICE)
+                        .build())
+            .headers(headers -> applyKisHeaders(headers, DAILY_ITEM_CHART_TR_ID))
+            .retrieve()
+            .onStatus(
+                status -> status.isError(),
+                response ->
+                    response
+                        .bodyToMono(String.class)
+                        .defaultIfEmpty("")
+                        .map(body -> stockChartApiException(response.statusCode().value(), body)))
+            .bodyToMono(String.class)
+            .map(this::readTree)
+            .timeout(REQUEST_TIMEOUT)
+            .onErrorMap(this::mapStockChartException)
+            .block();
+    return requireKisResponse(root, StockErrorCode.KIS_STOCK_CHART_API_FAILED);
   }
 
   private JsonNode fetchCurrentDailyPrice(String ticker) {
@@ -189,31 +193,35 @@ public class KisStockChartClient {
         ticker,
         CURRENT_DAILY_PRICE_TR_ID,
         DAILY_PERIOD_DIV_CODE);
-    return webClient
-        .get()
-        .uri(
-            uriBuilder ->
-                uriBuilder
-                    .path(CURRENT_DAILY_PRICE_PATH)
-                    .queryParam("FID_COND_MRKT_DIV_CODE", KRX_MARKET_DIV_CODE)
-                    .queryParam("FID_INPUT_ISCD", ticker)
-                    .queryParam("FID_PERIOD_DIV_CODE", DAILY_PERIOD_DIV_CODE)
-                    .queryParam("FID_ORG_ADJ_PRC", ADJUSTED_PRICE)
-                    .build())
-        .headers(headers -> applyKisHeaders(headers, CURRENT_DAILY_PRICE_TR_ID))
-        .retrieve()
-        .onStatus(
-            status -> status.isError(),
-            response ->
-                response
-                    .bodyToMono(String.class)
-                    .defaultIfEmpty("")
-                    .map(body -> stockDailyPriceApiException(response.statusCode().value(), body)))
-        .bodyToMono(String.class)
-        .map(this::readDailyPriceTree)
-        .timeout(REQUEST_TIMEOUT)
-        .onErrorMap(this::mapStockDailyPriceException)
-        .block();
+    JsonNode root =
+        webClient
+            .get()
+            .uri(
+                uriBuilder ->
+                    uriBuilder
+                        .path(CURRENT_DAILY_PRICE_PATH)
+                        .queryParam("FID_COND_MRKT_DIV_CODE", KRX_MARKET_DIV_CODE)
+                        .queryParam("FID_INPUT_ISCD", ticker)
+                        .queryParam("FID_PERIOD_DIV_CODE", DAILY_PERIOD_DIV_CODE)
+                        .queryParam("FID_ORG_ADJ_PRC", ADJUSTED_PRICE)
+                        .build())
+            .headers(headers -> applyKisHeaders(headers, CURRENT_DAILY_PRICE_TR_ID))
+            .retrieve()
+            .onStatus(
+                status -> status.isError(),
+                response ->
+                    response
+                        .bodyToMono(String.class)
+                        .defaultIfEmpty("")
+                        .map(
+                            body ->
+                                stockDailyPriceApiException(response.statusCode().value(), body)))
+            .bodyToMono(String.class)
+            .map(this::readDailyPriceTree)
+            .timeout(REQUEST_TIMEOUT)
+            .onErrorMap(this::mapStockDailyPriceException)
+            .block();
+    return requireKisResponse(root, StockErrorCode.KIS_STOCK_DAILY_PRICE_API_FAILED);
   }
 
   private void applyKisHeaders(HttpHeaders headers, String trId) {
@@ -270,6 +278,16 @@ public class KisStockChartClient {
         throwable.getClass().getSimpleName(),
         throwable.getMessage());
     return new StockException(StockErrorCode.KIS_STOCK_DAILY_PRICE_API_FAILED, throwable);
+  }
+
+  private JsonNode requireKisResponse(JsonNode root, StockErrorCode errorCode) {
+    if (root != null) {
+      return root;
+    }
+
+    log.warn(
+        "code={}, message={}, reason=empty-response", errorCode.getCode(), errorCode.getMessage());
+    throw new StockException(errorCode);
   }
 
   private JsonNode readTree(String body) {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockFinancialClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockFinancialClient.java
@@ -1,0 +1,156 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import com.example.elephantfinancelab_be.domain.chart.service.KisAccessTokenClient;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialApiType;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialPeriod;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import com.example.elephantfinancelab_be.global.config.KisProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class KisStockFinancialClient {
+
+  private static final String KRX_MARKET_DIV_CODE = "J";
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+  private final KisProperties kisProperties;
+  private final KisAccessTokenClient accessTokenClient;
+  private final ObjectMapper objectMapper;
+  private final WebClient webClient;
+
+  public KisStockFinancialClient(
+      KisProperties kisProperties,
+      KisAccessTokenClient accessTokenClient,
+      ObjectMapper objectMapper,
+      WebClient.Builder builder) {
+    this.kisProperties = kisProperties;
+    this.accessTokenClient = accessTokenClient;
+    this.objectMapper = objectMapper;
+    this.webClient = builder.baseUrl(normalizedBaseUrl(kisProperties.getBaseUrl())).build();
+  }
+
+  public List<JsonNode> fetchFinancial(
+      String ticker, StockFinancialApiType apiType, StockFinancialPeriod period) {
+    JsonNode root = fetchFinancialRoot(ticker, apiType, period);
+    if (!"0".equals(root.path("rt_cd").asText())) {
+      log.warn(
+          "code={}, message={}, apiType={}, msg_cd={}, msg={}",
+          StockErrorCode.KIS_STOCK_FINANCIAL_API_FAILED.getCode(),
+          StockErrorCode.KIS_STOCK_FINANCIAL_API_FAILED.getMessage(),
+          apiType,
+          root.path("msg_cd").asText(),
+          root.path("msg1").asText());
+      throw new StockException(StockErrorCode.KIS_STOCK_FINANCIAL_API_FAILED);
+    }
+
+    return toOutputList(root.path("output"));
+  }
+
+  private JsonNode fetchFinancialRoot(
+      String ticker, StockFinancialApiType apiType, StockFinancialPeriod period) {
+    log.debug(
+        "한국투자증권 재무제표 API 호출. ticker={}, apiType={}, trId={}, period={}",
+        ticker,
+        apiType,
+        apiType.getTrId(),
+        period);
+    return webClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path(apiType.getPath())
+                    .queryParam("FID_DIV_CLS_CODE", period.getKisDivClsCode())
+                    .queryParam("fid_cond_mrkt_div_code", KRX_MARKET_DIV_CODE)
+                    .queryParam("fid_input_iscd", ticker)
+                    .build())
+        .headers(headers -> applyKisHeaders(headers, apiType.getTrId()))
+        .retrieve()
+        .onStatus(
+            status -> status.isError(),
+            response ->
+                response
+                    .bodyToMono(String.class)
+                    .defaultIfEmpty("")
+                    .map(body -> stockFinancialApiException(response.statusCode().value(), body)))
+        .bodyToMono(String.class)
+        .map(this::readTree)
+        .timeout(REQUEST_TIMEOUT)
+        .onErrorMap(this::mapStockFinancialException)
+        .block();
+  }
+
+  private List<JsonNode> toOutputList(JsonNode output) {
+    List<JsonNode> items = new ArrayList<>();
+    if (!output.isArray()) {
+      return items;
+    }
+
+    output.forEach(items::add);
+    return items;
+  }
+
+  private void applyKisHeaders(HttpHeaders headers, String trId) {
+    headers.setContentType(
+        MediaType.parseMediaType(MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8"));
+    headers.setBearerAuth(accessTokenClient.getAccessToken());
+    headers.set("appkey", kisProperties.getAppKey());
+    headers.set("appsecret", kisProperties.getAppSecret());
+    headers.set("tr_id", trId);
+    headers.set("custtype", "P");
+  }
+
+  private RuntimeException stockFinancialApiException(int statusCode, String body) {
+    log.warn(
+        "code={}, message={}, status={}, responseBody={}",
+        StockErrorCode.KIS_STOCK_FINANCIAL_API_FAILED.getCode(),
+        StockErrorCode.KIS_STOCK_FINANCIAL_API_FAILED.getMessage(),
+        statusCode,
+        body);
+    return new StockException(StockErrorCode.KIS_STOCK_FINANCIAL_API_FAILED);
+  }
+
+  private Throwable mapStockFinancialException(Throwable throwable) {
+    if (throwable instanceof StockException) {
+      return throwable;
+    }
+    log.warn(
+        "code={}, message={}, exception={}, detail={}",
+        StockErrorCode.KIS_STOCK_FINANCIAL_API_FAILED.getCode(),
+        StockErrorCode.KIS_STOCK_FINANCIAL_API_FAILED.getMessage(),
+        throwable.getClass().getSimpleName(),
+        throwable.getMessage());
+    return new StockException(StockErrorCode.KIS_STOCK_FINANCIAL_API_FAILED, throwable);
+  }
+
+  private JsonNode readTree(String body) {
+    try {
+      return objectMapper.readTree(body);
+    } catch (JsonProcessingException e) {
+      log.atWarn()
+          .setCause(e)
+          .log(
+              "code={}, message={}, responseBody={}",
+              StockErrorCode.KIS_STOCK_FINANCIAL_RESPONSE_PARSE_FAILED.getCode(),
+              StockErrorCode.KIS_STOCK_FINANCIAL_RESPONSE_PARSE_FAILED.getMessage(),
+              body);
+      throw new StockException(StockErrorCode.KIS_STOCK_FINANCIAL_RESPONSE_PARSE_FAILED, e);
+    }
+  }
+
+  private String normalizedBaseUrl(String baseUrl) {
+    return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockFinancialClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockFinancialClient.java
@@ -103,11 +103,14 @@ public class KisStockFinancialClient {
   }
 
   private void applyKisHeaders(HttpHeaders headers, String trId) {
+    String appKey = kisProperties.getFinancialAppKeyOrDefault();
+    String appSecret = kisProperties.getFinancialAppSecretOrDefault();
+
     headers.setContentType(
         MediaType.parseMediaType(MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8"));
-    headers.setBearerAuth(accessTokenClient.getAccessToken());
-    headers.set("appkey", kisProperties.getAppKey());
-    headers.set("appsecret", kisProperties.getAppSecret());
+    headers.setBearerAuth(accessTokenClient.getAccessToken(appKey, appSecret));
+    headers.set("appkey", appKey);
+    headers.set("appsecret", appSecret);
     headers.set("tr_id", trId);
     headers.set("custtype", "P");
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockFinancialRedisService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockFinancialRedisService.java
@@ -1,0 +1,62 @@
+package com.example.elephantfinancelab_be.domain.stocks.service;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockFinancialResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialPeriod;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialStatement;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StockFinancialRedisService {
+
+  private static final String FINANCIAL_KEY_PREFIX = "stock:financial:";
+  private static final Duration FINANCIAL_CACHE_TTL = Duration.ofHours(1);
+
+  private final StringRedisTemplate stringRedisTemplate;
+  private final ObjectMapper objectMapper;
+
+  public void save(StockFinancialResDTO.Financial financial) {
+    try {
+      stringRedisTemplate
+          .opsForValue()
+          .set(
+              redisKey(financial.ticker(), financial.statement(), financial.period()),
+              objectMapper.writeValueAsString(financial),
+              FINANCIAL_CACHE_TTL);
+    } catch (JsonProcessingException e) {
+      throw new StockException(StockErrorCode.STOCK_FINANCIAL_CACHE_SERIALIZE_FAILED, e);
+    }
+  }
+
+  public StockFinancialResDTO.Financial find(
+      String ticker, StockFinancialStatement statement, StockFinancialPeriod period) {
+    String json = stringRedisTemplate.opsForValue().get(redisKey(ticker, statement, period));
+    if (json == null || json.isBlank()) {
+      return null;
+    }
+
+    try {
+      return objectMapper.readValue(json, StockFinancialResDTO.Financial.class);
+    } catch (JsonProcessingException e) {
+      throw new StockException(StockErrorCode.STOCK_FINANCIAL_CACHE_DESERIALIZE_FAILED, e);
+    }
+  }
+
+  private String redisKey(
+      String ticker, StockFinancialStatement statement, StockFinancialPeriod period) {
+    return FINANCIAL_KEY_PREFIX
+        + ticker.trim().toUpperCase(Locale.ROOT)
+        + ":"
+        + statement.name()
+        + ":"
+        + period.name();
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockFinancialRedisService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockFinancialRedisService.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StockFinancialRedisService {
 
-  private static final String FINANCIAL_KEY_PREFIX = "stock:financial:";
+  private static final String FINANCIAL_KEY_PREFIX = "stock:financial:v3:";
   private static final Duration FINANCIAL_CACHE_TTL = Duration.ofHours(1);
 
   private final StringRedisTemplate stringRedisTemplate;

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPricePushService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPricePushService.java
@@ -68,7 +68,16 @@ public class StockPricePushService {
           e);
     }
 
-    stockChartRealtimeService.updateAndPush(stock.getTicker(), parsed);
+    try {
+      stockChartRealtimeService.updateAndPush(stock.getTicker(), parsed);
+    } catch (RuntimeException e) {
+      log.warn(
+          "code={}, message={}, ticker={}",
+          StockErrorCode.STOCK_CHART_REALTIME_UPDATE_FAILED.getCode(),
+          StockErrorCode.STOCK_CHART_REALTIME_UPDATE_FAILED.getMessage(),
+          stock.getTicker(),
+          e);
+    }
   }
 
   private String destination(String ticker) {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParser.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParser.java
@@ -60,7 +60,7 @@ public class StockPriceRealtimeParser {
     }
 
     String[] fields = parts[3].split("\\^", -1);
-    if (fields.length <= CHANGE_RATE_FIELD) {
+    if (fields.length < RESPONSE_FIELD_COUNT) {
       log.warn(
           "code={}, message={}, count={}",
           StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getCode(),
@@ -73,7 +73,7 @@ public class StockPriceRealtimeParser {
     List<ParsedStockPrice> prices = new ArrayList<>();
     for (int index = 0; index < dataCount; index++) {
       int offset = index * RESPONSE_FIELD_COUNT;
-      if (fields.length <= offset + CHANGE_RATE_FIELD) {
+      if (fields.length < offset + RESPONSE_FIELD_COUNT) {
         log.warn(
             "code={}, message={}, item={}, count={}",
             StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getCode(),

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParser.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParser.java
@@ -108,7 +108,12 @@ public class StockPriceRealtimeParser {
     try {
       return Integer.parseInt(dataCount);
     } catch (NumberFormatException e) {
-      return 1;
+      log.warn(
+          "code={}, message={}, dataCount={}",
+          StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getCode(),
+          StockErrorCode.KIS_STOCK_PRICE_REALTIME_MESSAGE_INVALID.getMessage(),
+          dataCount);
+      return 0;
     }
   }
 

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockDailyPriceQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockDailyPriceQueryServiceImpl.java
@@ -34,7 +34,7 @@ public class StockDailyPriceQueryServiceImpl implements StockDailyPriceQueryServ
 
   private String normalizeTicker(String ticker) {
     if (ticker == null || ticker.isBlank()) {
-      throw new StockException(StockErrorCode.STOCK_NOT_FOUND);
+      throw new StockException(StockErrorCode.INVALID_STOCK_TICKER);
     }
     return ticker.trim().toUpperCase(Locale.ROOT);
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockFinancialQueryService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockFinancialQueryService.java
@@ -1,0 +1,8 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockFinancialResDTO;
+
+public interface StockFinancialQueryService {
+
+  StockFinancialResDTO.Financial getFinancial(String ticker, String statement, String period);
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockFinancialQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockFinancialQueryServiceImpl.java
@@ -1,0 +1,222 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockFinancialResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialApiType;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialPeriod;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialStatement;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import com.example.elephantfinancelab_be.domain.stocks.repository.StockRepository;
+import com.example.elephantfinancelab_be.domain.stocks.service.KisStockFinancialClient;
+import com.example.elephantfinancelab_be.domain.stocks.service.StockFinancialRedisService;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StockFinancialQueryServiceImpl implements StockFinancialQueryService {
+
+  private static final int COLUMN_COUNT = 4;
+  private static final String PERIOD_FIELD_NAME = "stac_yymm";
+
+  private final StockRepository stockRepository;
+  private final StockFinancialRedisService stockFinancialRedisService;
+  private final KisStockFinancialClient kisStockFinancialClient;
+
+  @Override
+  public StockFinancialResDTO.Financial getFinancial(
+      String ticker, String statement, String period) {
+    StockFinancialStatement financialStatement = StockFinancialStatement.from(statement);
+    StockFinancialPeriod financialPeriod = StockFinancialPeriod.from(period);
+    Stock stock =
+        stockRepository
+            .findByTicker(normalizeTicker(ticker))
+            .orElseThrow(() -> new StockException(StockErrorCode.STOCK_NOT_FOUND));
+
+    StockFinancialResDTO.Financial cachedFinancial =
+        findCachedFinancial(stock, financialStatement, financialPeriod);
+    if (cachedFinancial != null) {
+      log.info(
+          "종목 재무제표 캐시 조회 성공. ticker={}, statement={}, period={}",
+          stock.getTicker(),
+          financialStatement,
+          financialPeriod);
+      return cachedFinancial;
+    }
+
+    Map<StockFinancialApiType, List<JsonNode>> outputByApi =
+        fetchOutputByApi(stock.getTicker(), financialStatement, financialPeriod);
+    StockFinancialResDTO.Financial financial =
+        toFinancialResponse(stock, financialStatement, financialPeriod, outputByApi);
+    saveFinancialCache(stock, financial);
+    return financial;
+  }
+
+  private Map<StockFinancialApiType, List<JsonNode>> fetchOutputByApi(
+      String ticker, StockFinancialStatement statement, StockFinancialPeriod period) {
+    Map<StockFinancialApiType, List<JsonNode>> outputByApi =
+        new EnumMap<>(StockFinancialApiType.class);
+    statement.getMetrics().stream()
+        .map(StockFinancialStatement.Metric::apiType)
+        .distinct()
+        .forEach(
+            apiType ->
+                outputByApi.put(
+                    apiType, kisStockFinancialClient.fetchFinancial(ticker, apiType, period)));
+    return outputByApi;
+  }
+
+  private StockFinancialResDTO.Financial toFinancialResponse(
+      Stock stock,
+      StockFinancialStatement statement,
+      StockFinancialPeriod period,
+      Map<StockFinancialApiType, List<JsonNode>> outputByApi) {
+    List<String> periodKeys = latestPeriodKeys(outputByApi);
+    List<String> columns =
+        periodKeys.stream().map(periodKey -> columnLabel(periodKey, period)).toList();
+    Map<StockFinancialApiType, Map<String, JsonNode>> nodeByApiAndPeriod =
+        nodeByApiAndPeriod(outputByApi);
+    List<StockFinancialResDTO.Row> rows =
+        statement.getMetrics().stream()
+            .map(metric -> toRow(metric, periodKeys, nodeByApiAndPeriod))
+            .toList();
+
+    return new StockFinancialResDTO.Financial(
+        stock.getTicker(), stock.getName(), statement, period, statement.getUnit(), columns, rows);
+  }
+
+  private List<String> latestPeriodKeys(Map<StockFinancialApiType, List<JsonNode>> outputByApi) {
+    return outputByApi.values().stream()
+        .flatMap(List::stream)
+        .map(node -> textValue(node, PERIOD_FIELD_NAME))
+        .filter(Objects::nonNull)
+        .distinct()
+        .sorted(Comparator.reverseOrder())
+        .limit(COLUMN_COUNT)
+        .sorted()
+        .toList();
+  }
+
+  private Map<StockFinancialApiType, Map<String, JsonNode>> nodeByApiAndPeriod(
+      Map<StockFinancialApiType, List<JsonNode>> outputByApi) {
+    Map<StockFinancialApiType, Map<String, JsonNode>> result =
+        new EnumMap<>(StockFinancialApiType.class);
+    outputByApi.forEach(
+        (apiType, nodes) -> {
+          Map<String, JsonNode> byPeriod = new LinkedHashMap<>();
+          nodes.forEach(
+              node -> {
+                String periodKey = textValue(node, PERIOD_FIELD_NAME);
+                if (periodKey != null) {
+                  byPeriod.putIfAbsent(periodKey, node);
+                }
+              });
+          result.put(apiType, byPeriod);
+        });
+    return result;
+  }
+
+  private StockFinancialResDTO.Row toRow(
+      StockFinancialStatement.Metric metric,
+      List<String> periodKeys,
+      Map<StockFinancialApiType, Map<String, JsonNode>> nodeByApiAndPeriod) {
+    Map<String, JsonNode> nodeByPeriod =
+        nodeByApiAndPeriod.getOrDefault(metric.apiType(), Map.of());
+    List<String> values =
+        periodKeys.stream()
+            .map(periodKey -> nodeByPeriod.get(periodKey))
+            .map(node -> node == null ? "" : financialValue(node, metric.fieldName()))
+            .toList();
+    return new StockFinancialResDTO.Row(metric.label(), values);
+  }
+
+  private String columnLabel(String periodKey, StockFinancialPeriod period) {
+    if (periodKey.length() != 6) {
+      return periodKey;
+    }
+
+    String year = periodKey.substring(2, 4) + "년";
+    if (period == StockFinancialPeriod.YEAR) {
+      return year;
+    }
+
+    try {
+      int month = Integer.parseInt(periodKey.substring(4, 6));
+      int quarter = Math.max(1, Math.min(4, (month - 1) / 3 + 1));
+      return year + " " + quarter + "Q";
+    } catch (NumberFormatException e) {
+      return periodKey;
+    }
+  }
+
+  private String financialValue(JsonNode node, String fieldName) {
+    String value = textValue(node, fieldName);
+    if (value == null) {
+      return "";
+    }
+
+    try {
+      return new BigDecimal(value.trim().replace(",", "")).stripTrailingZeros().toPlainString();
+    } catch (NumberFormatException e) {
+      return value;
+    }
+  }
+
+  private String textValue(JsonNode node, String fieldName) {
+    String value = node.path(fieldName).asText();
+    return value.isBlank() ? null : value;
+  }
+
+  private StockFinancialResDTO.Financial findCachedFinancial(
+      Stock stock, StockFinancialStatement statement, StockFinancialPeriod period) {
+    try {
+      return stockFinancialRedisService.find(stock.getTicker(), statement, period);
+    } catch (RuntimeException e) {
+      log.warn(
+          "code={}, message={}, ticker={}, statement={}, period={}",
+          StockErrorCode.STOCK_FINANCIAL_CACHE_DESERIALIZE_FAILED.getCode(),
+          StockErrorCode.STOCK_FINANCIAL_CACHE_DESERIALIZE_FAILED.getMessage(),
+          stock.getTicker(),
+          statement,
+          period,
+          e);
+      return null;
+    }
+  }
+
+  private void saveFinancialCache(Stock stock, StockFinancialResDTO.Financial financial) {
+    try {
+      stockFinancialRedisService.save(financial);
+    } catch (RuntimeException e) {
+      log.warn(
+          "code={}, message={}, ticker={}, statement={}, period={}",
+          StockErrorCode.STOCK_FINANCIAL_CACHE_SERIALIZE_FAILED.getCode(),
+          StockErrorCode.STOCK_FINANCIAL_CACHE_SERIALIZE_FAILED.getMessage(),
+          stock.getTicker(),
+          financial.statement(),
+          financial.period(),
+          e);
+    }
+  }
+
+  private String normalizeTicker(String ticker) {
+    if (ticker == null || ticker.isBlank()) {
+      throw new StockException(StockErrorCode.STOCK_NOT_FOUND);
+    }
+    return ticker.trim().toUpperCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockFinancialQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockFinancialQueryServiceImpl.java
@@ -12,6 +12,7 @@ import com.example.elephantfinancelab_be.domain.stocks.service.KisStockFinancial
 import com.example.elephantfinancelab_be.domain.stocks.service.StockFinancialRedisService;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
@@ -92,7 +93,13 @@ public class StockFinancialQueryServiceImpl implements StockFinancialQueryServic
         nodeByApiAndPeriod(outputByApi);
     List<StockFinancialResDTO.Row> rows =
         statement.getMetrics().stream()
-            .map(metric -> toRow(metric, periodKeys, nodeByApiAndPeriod))
+            .map(
+                metric ->
+                    toRow(
+                        metric,
+                        periodKeys,
+                        nodeByApiAndPeriod,
+                        shouldConvertCumulativeToQuarterly(statement, period)))
             .toList();
 
     return new StockFinancialResDTO.Financial(
@@ -133,15 +140,51 @@ public class StockFinancialQueryServiceImpl implements StockFinancialQueryServic
   private StockFinancialResDTO.Row toRow(
       StockFinancialStatement.Metric metric,
       List<String> periodKeys,
-      Map<StockFinancialApiType, Map<String, JsonNode>> nodeByApiAndPeriod) {
+      Map<StockFinancialApiType, Map<String, JsonNode>> nodeByApiAndPeriod,
+      boolean convertCumulativeToQuarterly) {
     Map<String, JsonNode> nodeByPeriod =
         nodeByApiAndPeriod.getOrDefault(metric.apiType(), Map.of());
-    List<String> values =
-        periodKeys.stream()
-            .map(periodKey -> nodeByPeriod.get(periodKey))
-            .map(node -> node == null ? "" : financialValue(node, metric.fieldName()))
-            .toList();
+    List<String> values = new ArrayList<>();
+    BigDecimal previousValue = null;
+    String previousPeriodKey = null;
+
+    for (String periodKey : periodKeys) {
+      JsonNode node = nodeByPeriod.get(periodKey);
+      String rawValue = node == null ? null : textValue(node, metric.fieldName());
+      if (rawValue == null) {
+        values.add("");
+        previousValue = null;
+        previousPeriodKey = null;
+        continue;
+      }
+
+      if (!convertCumulativeToQuarterly) {
+        values.add(financialValue(rawValue));
+        continue;
+      }
+
+      BigDecimal currentValue = parseFinancialValue(rawValue);
+      if (currentValue == null || isMissingFinancialValue(currentValue)) {
+        values.add(currentValue == null ? financialValue(rawValue) : "");
+        previousValue = null;
+        previousPeriodKey = null;
+        continue;
+      }
+
+      BigDecimal displayValue =
+          isSameYear(previousPeriodKey, periodKey) && previousValue != null
+              ? currentValue.subtract(previousValue)
+              : currentValue;
+      values.add(formatFinancialValue(displayValue));
+      previousValue = currentValue;
+      previousPeriodKey = periodKey;
+    }
     return new StockFinancialResDTO.Row(metric.label(), values);
+  }
+
+  private boolean shouldConvertCumulativeToQuarterly(
+      StockFinancialStatement statement, StockFinancialPeriod period) {
+    return statement == StockFinancialStatement.INCOME && period == StockFinancialPeriod.QUARTER;
   }
 
   private String columnLabel(String periodKey, StockFinancialPeriod period) {
@@ -169,11 +212,41 @@ public class StockFinancialQueryServiceImpl implements StockFinancialQueryServic
       return "";
     }
 
-    try {
-      return new BigDecimal(value.trim().replace(",", "")).stripTrailingZeros().toPlainString();
-    } catch (NumberFormatException e) {
+    return financialValue(value);
+  }
+
+  private String financialValue(String value) {
+    BigDecimal decimal = parseFinancialValue(value);
+    if (decimal == null) {
       return value;
     }
+    if (isMissingFinancialValue(decimal)) {
+      return "";
+    }
+    return formatFinancialValue(decimal);
+  }
+
+  private BigDecimal parseFinancialValue(String value) {
+    try {
+      return new BigDecimal(value.trim().replace(",", ""));
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  private String formatFinancialValue(BigDecimal value) {
+    return value.stripTrailingZeros().toPlainString();
+  }
+
+  private boolean isMissingFinancialValue(BigDecimal value) {
+    return BigDecimal.valueOf(99.99).compareTo(value) == 0;
+  }
+
+  private boolean isSameYear(String previousPeriodKey, String periodKey) {
+    return previousPeriodKey != null
+        && previousPeriodKey.length() >= 4
+        && periodKey.length() >= 4
+        && previousPeriodKey.substring(0, 4).equals(periodKey.substring(0, 4));
   }
 
   private String textValue(JsonNode node, String fieldName) {

--- a/src/main/java/com/example/elephantfinancelab_be/global/config/KisProperties.java
+++ b/src/main/java/com/example/elephantfinancelab_be/global/config/KisProperties.java
@@ -18,5 +18,19 @@ public class KisProperties {
   @NotBlank private String appSecret;
   @NotBlank private String baseUrl;
   @NotBlank private String websocketUrl;
+  private String financialAppKey;
+  private String financialAppSecret;
   private boolean websocketEnabled = true;
+
+  public String getFinancialAppKeyOrDefault() {
+    return hasText(financialAppKey) ? financialAppKey : appKey;
+  }
+
+  public String getFinancialAppSecretOrDefault() {
+    return hasText(financialAppSecret) ? financialAppSecret : appSecret;
+  }
+
+  private boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,6 +86,8 @@ kis:
   app-key: ${KIS_APP_KEY}
   app-secret: ${KIS_APP_SECRET}
   base-url: ${KIS_BASE_URL:https://openapi.koreainvestment.com:9443}
+  financial-app-key: ${KIS_FINANCIAL_APP_KEY}
+  financial-app-secret: ${KIS_FINANCIAL_APP_SECRET}
   websocket-url: ${KIS_WS_URL:ws://ops.koreainvestment.com:21000}
 
 logging:

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParserTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParserTest.java
@@ -75,6 +75,15 @@ class StockPriceRealtimeParserTest {
     assertThat(result).isEmpty();
   }
 
+  @Test
+  void parseKisRealtimeStockPriceMessageSkipsTruncatedItem() {
+    String message = "0|H0STCNT0|001|005930^093354^71900^5^-100^-0.14";
+
+    var result = parser.parseAll(message);
+
+    assertThat(result).isEmpty();
+  }
+
   private String item(
       String ticker,
       String tradeTime,

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParserTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/StockPriceRealtimeParserTest.java
@@ -65,6 +65,16 @@ class StockPriceRealtimeParserTest {
     assertThat(result.get(1).ticker()).isEqualTo("000660");
   }
 
+  @Test
+  void dropMessageWhenDataCountIsInvalid() {
+    String message =
+        "0|H0STCNT0|abc|" + item("005930", "093354", "71900", "5", "-100", "-0.14", "20230612");
+
+    var result = parser.parseAll(message);
+
+    assertThat(result).isEmpty();
+  }
+
   private String item(
       String ticker,
       String tradeTime,

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockFinancialQueryServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockFinancialQueryServiceImplTest.java
@@ -1,0 +1,100 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockFinancialResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialApiType;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialPeriod;
+import com.example.elephantfinancelab_be.domain.stocks.repository.StockRepository;
+import com.example.elephantfinancelab_be.domain.stocks.service.KisStockFinancialClient;
+import com.example.elephantfinancelab_be.domain.stocks.service.StockFinancialRedisService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class StockFinancialQueryServiceImplTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final StockRepository stockRepository = mock(StockRepository.class);
+  private final StockFinancialRedisService stockFinancialRedisService =
+      mock(StockFinancialRedisService.class);
+  private final KisStockFinancialClient kisStockFinancialClient =
+      mock(KisStockFinancialClient.class);
+  private final StockFinancialQueryServiceImpl service =
+      new StockFinancialQueryServiceImpl(
+          stockRepository, stockFinancialRedisService, kisStockFinancialClient);
+
+  @Test
+  void convertsQuarterlyIncomeStatementFromCumulativeToQuarterlyValues() {
+    Stock stock = Stock.builder().ticker("005930").name("삼성전자").build();
+    when(stockRepository.findByTicker("005930")).thenReturn(Optional.of(stock));
+    when(stockFinancialRedisService.find(any(), any(), any())).thenReturn(null);
+    when(kisStockFinancialClient.fetchFinancial(
+            "005930", StockFinancialApiType.INCOME, StockFinancialPeriod.QUARTER))
+        .thenReturn(
+            List.of(
+                incomeNode("202503", "791405", "66853", "99.99"),
+                incomeNode("202506", "1537068", "113613", "99.99"),
+                incomeNode("202509", "2397686", "235274", "99.99"),
+                incomeNode("202512", "3336059", "436011", "99.99")));
+
+    StockFinancialResDTO.Financial result = service.getFinancial("005930", "INCOME", "QUARTER");
+
+    assertThat(result.unit()).isEqualTo("억원");
+    assertThat(result.columns()).containsExactly("25년 1Q", "25년 2Q", "25년 3Q", "25년 4Q");
+    assertThat(rowValues(result, "매출액")).containsExactly("791405", "745663", "860618", "938373");
+    assertThat(rowValues(result, "영업 이익")).containsExactly("66853", "46760", "121661", "200737");
+    assertThat(rowValues(result, "감가상각비")).containsExactly("", "", "", "");
+  }
+
+  @Test
+  void doesNotSubtractIncomeValuesAcrossDifferentYears() {
+    Stock stock = Stock.builder().ticker("005930").name("삼성전자").build();
+    when(stockRepository.findByTicker("005930")).thenReturn(Optional.of(stock));
+    when(stockFinancialRedisService.find(any(), any(), any())).thenReturn(null);
+    when(kisStockFinancialClient.fetchFinancial(
+            "005930", StockFinancialApiType.INCOME, StockFinancialPeriod.QUARTER))
+        .thenReturn(
+            List.of(
+                incomeNode("202412", "3000000", "400000", "99.99"),
+                incomeNode("202503", "700000", "100000", "99.99"),
+                incomeNode("202506", "1500000", "250000", "99.99")));
+
+    StockFinancialResDTO.Financial result = service.getFinancial("005930", "INCOME", "QUARTER");
+
+    assertThat(rowValues(result, "매출액")).containsExactly("3000000", "700000", "800000");
+  }
+
+  private List<String> rowValues(StockFinancialResDTO.Financial financial, String label) {
+    return financial.rows().stream()
+        .filter(row -> row.label().equals(label))
+        .findFirst()
+        .orElseThrow()
+        .values();
+  }
+
+  private JsonNode incomeNode(
+      String periodKey, String saleAccount, String operatingProfit, String depreciationCost) {
+    return objectMapper
+        .createObjectNode()
+        .put("stac_yymm", periodKey)
+        .put("sale_account", saleAccount)
+        .put("sale_cost", "0")
+        .put("sale_totl_prfi", "0")
+        .put("depr_cost", depreciationCost)
+        .put("sell_mang", "0")
+        .put("bsop_prti", operatingProfit)
+        .put("bsop_non_ernn", "0")
+        .put("bsop_non_expn", "0")
+        .put("op_prfi", "0")
+        .put("spec_prfi", "0")
+        .put("spec_loss", "0")
+        .put("thtr_ntin", "0");
+  }
+}


### PR DESCRIPTION
## 💡 Issue
- Close #39

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- 종목 상세 페이지에서 사용할 GET /api/stocks/{ticker}/financial 재무제표 조회 API 추가
- 손익계산서, 재무상태표, 재무비율/수익성비율 데이터를 조회하고, 프론트에서 표로 렌더링하기 쉬운 columns/rows 구조로 응답
 
## 🛠️ Changes
- StockController에 /api/stocks/{ticker}/financial endpoint 추가
- StockFinancialQueryService, KisStockFinancialClient, StockFinancialRedisService 추가
- INCOME, BALANCE, RATIO statement와 QUARTER, YEAR period 처리 추가
- KIS 손익계산서, 대차대조표, 재무비율, 수익성비율 API 연동
- Redis 캐싱 적용: stock:financial:{ticker}:{statement}:{period}, TTL 1시간

## 📸 Screenshots
실제 앱 키 및 앱 시크릿 연동 후 첨부

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 주식 관련 API 추가: 종목 요약, 차트, 일별 시세, 재무제표 및 관련 DTO/엔티티/레포지토/서비스
  * KIS 연동 클라이언트(요약/가격/차트/재무) 및 WebSocket 기반 실시간 가격·차트 푸시
  * Redis 캐시·락 기반 저장/조회 및 스케줄링 기반 플러시
  * WebClient 빈과 스케줄링 활성화, 공개 WebSocket 엔드포인트(/ws) 허용

* **Improvements**
  * 오류 코드 추가 및 로그/예외 메시지 형식 표준화
  * 접근토큰 키 전략·로깅 개선 및 금융용 자격증명 설정 추가

* **Tests**
  * 실시간 파서·방향 매핑·재무 변환 유닛 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elephant-finance-lab/BE/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->