### PR TITLE
[FEAT] 종목 정보 집계용 API

### DIFF
--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/controller/StockController.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/controller/StockController.java
@@ -3,10 +3,12 @@ package com.example.elephantfinancelab_be.domain.stocks.controller;
 import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockChartResDTO;
 import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockDailyPriceResDTO;
 import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockFinancialResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockInfoResDTO;
 import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
 import com.example.elephantfinancelab_be.domain.stocks.service.query.StockChartQueryService;
 import com.example.elephantfinancelab_be.domain.stocks.service.query.StockDailyPriceQueryService;
 import com.example.elephantfinancelab_be.domain.stocks.service.query.StockFinancialQueryService;
+import com.example.elephantfinancelab_be.domain.stocks.service.query.StockInfoQueryService;
 import com.example.elephantfinancelab_be.domain.stocks.service.query.StockQueryService;
 import com.example.elephantfinancelab_be.global.apiPayload.ApiResponse;
 import com.example.elephantfinancelab_be.global.apiPayload.code.GeneralSuccessCode;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 @Tag(name = "Stocks", description = "종목 관련 API")
 @RestController
@@ -31,6 +34,7 @@ public class StockController {
   private final StockChartQueryService stockChartQueryService;
   private final StockDailyPriceQueryService stockDailyPriceQueryService;
   private final StockFinancialQueryService stockFinancialQueryService;
+  private final StockInfoQueryService stockInfoQueryService;
 
   @Operation(summary = "종목 상세 상단 조회", description = "국내주식 종목명, 현재가, 전일 대비 정보를 조회합니다.")
   @GetMapping("/{ticker}/summary")
@@ -39,6 +43,20 @@ public class StockController {
     StockResDTO.Summary result = stockQueryService.getSummary(ticker);
     return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
         .body(ApiResponse.of(GeneralSuccessCode.OK, result));
+  }
+
+  @Operation(summary = "종목 정보 탭 요약 조회", description = "시세 요약과 주요 재무 3개 항목을 한 번에 조회합니다.")
+  @GetMapping("/{ticker}/info")
+  public Mono<ResponseEntity<ApiResponse<StockInfoResDTO.Info>>> getInfo(
+      @Parameter(description = "종목코드. 예: 005930") @PathVariable String ticker,
+      @Parameter(description = "QUARTER, YEAR. 기본값 QUARTER") @RequestParam(defaultValue = "QUARTER")
+          String period) {
+    return stockInfoQueryService
+        .getInfo(ticker, period)
+        .map(
+            result ->
+                ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
+                    .body(ApiResponse.of(GeneralSuccessCode.OK, result)));
   }
 
   @Operation(summary = "종목 차트 시계열 조회", description = "라인/캔들 차트 초기 데이터를 조회합니다.")

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/dto/res/StockInfoResDTO.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/dto/res/StockInfoResDTO.java
@@ -1,0 +1,23 @@
+package com.example.elephantfinancelab_be.domain.stocks.dto.res;
+
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialPeriod;
+import java.util.List;
+
+public class StockInfoResDTO {
+
+  public record Info(
+      String ticker, String nameKor, Price price, FinancialSummary financialSummary) {}
+
+  public record Price(
+      Long dayLowPriceKrw,
+      Long dayHighPriceKrw,
+      Long yearLowPriceKrw,
+      Long yearHighPriceKrw,
+      Long openPriceKrw,
+      Long closePriceKrw) {}
+
+  public record FinancialSummary(
+      StockFinancialPeriod period, String unit, List<String> columns, List<Row> rows) {}
+
+  public record Row(String label, List<String> values) {}
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockInfoQueryService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockInfoQueryService.java
@@ -1,0 +1,9 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockInfoResDTO;
+import reactor.core.publisher.Mono;
+
+public interface StockInfoQueryService {
+
+  Mono<StockInfoResDTO.Info> getInfo(String ticker, String period);
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockInfoQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockInfoQueryServiceImpl.java
@@ -7,7 +7,6 @@ import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialPeri
 import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +22,7 @@ public class StockInfoQueryServiceImpl implements StockInfoQueryService {
   private static final String ONE_DAY_RANGE = "1D";
   private static final String ONE_YEAR_RANGE = "1Y";
   private static final String INCOME_STATEMENT = "INCOME";
-  private static final Set<String> FINANCIAL_SUMMARY_LABELS = Set.of("매출액", "매출 총 이익", "당기순이익");
+  private static final List<String> FINANCIAL_SUMMARY_LABELS = List.of("매출액", "매출 총 이익", "당기순이익");
 
   private final StockChartQueryService stockChartQueryService;
   private final StockFinancialQueryService stockFinancialQueryService;
@@ -74,13 +73,23 @@ public class StockInfoQueryServiceImpl implements StockInfoQueryService {
 
   private StockInfoResDTO.FinancialSummary toFinancialSummary(
       StockFinancialResDTO.Financial financial) {
+    List<StockFinancialResDTO.Row> financialRows = safeList(financial.rows());
     List<StockInfoResDTO.Row> rows =
-        financial.rows().stream()
-            .filter(row -> FINANCIAL_SUMMARY_LABELS.contains(row.label()))
-            .map(row -> new StockInfoResDTO.Row(row.label(), row.values()))
+        FINANCIAL_SUMMARY_LABELS.stream()
+            .map(label -> findFinancialRow(financialRows, label))
+            .filter(row -> row != null)
+            .map(row -> new StockInfoResDTO.Row(row.label(), safeList(row.values())))
             .toList();
     return new StockInfoResDTO.FinancialSummary(
-        financial.period(), financial.unit(), financial.columns(), rows);
+        financial.period(), financial.unit(), safeList(financial.columns()), rows);
+  }
+
+  private StockFinancialResDTO.Row findFinancialRow(
+      List<StockFinancialResDTO.Row> rows, String label) {
+    return rows.stream()
+        .filter(row -> row != null && label.equals(row.label()))
+        .findFirst()
+        .orElse(null);
   }
 
   private Long minLowPrice(List<StockChartResDTO.DataPoint> data) {
@@ -117,6 +126,10 @@ public class StockInfoQueryServiceImpl implements StockInfoQueryService {
       return null;
     }
     return data.get(data.size() - 1);
+  }
+
+  private <T> List<T> safeList(List<T> values) {
+    return values == null ? List.of() : values;
   }
 
   private <T> Mono<T> blockingMono(BlockingSupplier<T> supplier) {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockInfoQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockInfoQueryServiceImpl.java
@@ -1,0 +1,131 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockChartResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockFinancialResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockInfoResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialPeriod;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StockInfoQueryServiceImpl implements StockInfoQueryService {
+
+  private static final String LINE_CHART_TYPE = "LINE";
+  private static final String ONE_DAY_RANGE = "1D";
+  private static final String ONE_YEAR_RANGE = "1Y";
+  private static final String INCOME_STATEMENT = "INCOME";
+  private static final Set<String> FINANCIAL_SUMMARY_LABELS = Set.of("매출액", "매출 총 이익", "당기순이익");
+
+  private final StockChartQueryService stockChartQueryService;
+  private final StockFinancialQueryService stockFinancialQueryService;
+
+  @Override
+  public Mono<StockInfoResDTO.Info> getInfo(String ticker, String period) {
+    StockFinancialPeriod financialPeriod = StockFinancialPeriod.from(period);
+    Mono<StockChartResDTO.Chart> oneDayChartMono =
+        blockingMono(() -> stockChartQueryService.getChart(ticker, ONE_DAY_RANGE, LINE_CHART_TYPE));
+    Mono<StockChartResDTO.Chart> oneYearChartMono =
+        blockingMono(
+            () -> stockChartQueryService.getChart(ticker, ONE_YEAR_RANGE, LINE_CHART_TYPE));
+    Mono<StockFinancialResDTO.Financial> financialMono =
+        blockingMono(
+            () ->
+                stockFinancialQueryService.getFinancial(
+                    ticker, INCOME_STATEMENT, financialPeriod.name()));
+
+    return Mono.zip(oneDayChartMono, oneYearChartMono, financialMono)
+        .map(tuple -> toInfo(tuple.getT1(), tuple.getT2(), tuple.getT3()));
+  }
+
+  private StockInfoResDTO.Info toInfo(
+      StockChartResDTO.Chart oneDayChart,
+      StockChartResDTO.Chart oneYearChart,
+      StockFinancialResDTO.Financial financial) {
+    return new StockInfoResDTO.Info(
+        financial.ticker(),
+        financial.nameKor(),
+        toPrice(oneDayChart, oneYearChart),
+        toFinancialSummary(financial));
+  }
+
+  private StockInfoResDTO.Price toPrice(
+      StockChartResDTO.Chart oneDayChart, StockChartResDTO.Chart oneYearChart) {
+    List<StockChartResDTO.DataPoint> oneDayData = oneDayChart.data();
+    StockChartResDTO.DataPoint firstPoint = firstPoint(oneDayData);
+    StockChartResDTO.DataPoint lastPoint = lastPoint(oneDayData);
+
+    return new StockInfoResDTO.Price(
+        minLowPrice(oneDayData),
+        maxHighPrice(oneDayData),
+        minLowPrice(oneYearChart.data()),
+        maxHighPrice(oneYearChart.data()),
+        firstPoint == null ? null : firstPoint.open(),
+        lastPoint == null ? null : lastPoint.close());
+  }
+
+  private StockInfoResDTO.FinancialSummary toFinancialSummary(
+      StockFinancialResDTO.Financial financial) {
+    List<StockInfoResDTO.Row> rows =
+        financial.rows().stream()
+            .filter(row -> FINANCIAL_SUMMARY_LABELS.contains(row.label()))
+            .map(row -> new StockInfoResDTO.Row(row.label(), row.values()))
+            .toList();
+    return new StockInfoResDTO.FinancialSummary(
+        financial.period(), financial.unit(), financial.columns(), rows);
+  }
+
+  private Long minLowPrice(List<StockChartResDTO.DataPoint> data) {
+    if (data == null || data.isEmpty()) {
+      return null;
+    }
+    return data.stream()
+        .map(StockChartResDTO.DataPoint::low)
+        .filter(value -> value != null)
+        .min(Comparator.naturalOrder())
+        .orElse(null);
+  }
+
+  private Long maxHighPrice(List<StockChartResDTO.DataPoint> data) {
+    if (data == null || data.isEmpty()) {
+      return null;
+    }
+    return data.stream()
+        .map(StockChartResDTO.DataPoint::high)
+        .filter(value -> value != null)
+        .max(Comparator.naturalOrder())
+        .orElse(null);
+  }
+
+  private StockChartResDTO.DataPoint firstPoint(List<StockChartResDTO.DataPoint> data) {
+    if (data == null || data.isEmpty()) {
+      return null;
+    }
+    return data.get(0);
+  }
+
+  private StockChartResDTO.DataPoint lastPoint(List<StockChartResDTO.DataPoint> data) {
+    if (data == null || data.isEmpty()) {
+      return null;
+    }
+    return data.get(data.size() - 1);
+  }
+
+  private <T> Mono<T> blockingMono(BlockingSupplier<T> supplier) {
+    return Mono.fromCallable(supplier::get).subscribeOn(Schedulers.boundedElastic());
+  }
+
+  @FunctionalInterface
+  private interface BlockingSupplier<T> {
+
+    T get() throws StockException;
+  }
+}

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockInfoQueryServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockInfoQueryServiceImplTest.java
@@ -45,6 +45,41 @@ class StockInfoQueryServiceImplTest {
         .containsExactly("매출액", "매출 총 이익", "당기순이익");
   }
 
+  @Test
+  void fallsBackToEmptyFinancialListsWhenFinancialRowsOrColumnsAreNull() {
+    when(stockChartQueryService.getChart("005930", "1D", "LINE")).thenReturn(oneDayChart());
+    when(stockChartQueryService.getChart("005930", "1Y", "LINE")).thenReturn(oneYearChart());
+    when(stockFinancialQueryService.getFinancial("005930", "INCOME", "QUARTER"))
+        .thenReturn(
+            new StockFinancialResDTO.Financial(
+                "005930",
+                "삼성전자",
+                StockFinancialStatement.INCOME,
+                StockFinancialPeriod.QUARTER,
+                "억원",
+                null,
+                null));
+
+    StockInfoResDTO.Info result = service.getInfo("005930", "QUARTER").block();
+
+    assertThat(result.financialSummary().columns()).isEmpty();
+    assertThat(result.financialSummary().rows()).isEmpty();
+  }
+
+  @Test
+  void ordersFinancialRowsBySummaryLabelOrder() {
+    when(stockChartQueryService.getChart("005930", "1D", "LINE")).thenReturn(oneDayChart());
+    when(stockChartQueryService.getChart("005930", "1Y", "LINE")).thenReturn(oneYearChart());
+    when(stockFinancialQueryService.getFinancial("005930", "INCOME", "QUARTER"))
+        .thenReturn(shuffledFinancial());
+
+    StockInfoResDTO.Info result = service.getInfo("005930", "QUARTER").block();
+
+    assertThat(result.financialSummary().rows())
+        .extracting(StockInfoResDTO.Row::label)
+        .containsExactly("매출액", "매출 총 이익", "당기순이익");
+  }
+
   private StockChartResDTO.Chart oneDayChart() {
     return new StockChartResDTO.Chart(
         "005930",
@@ -86,5 +121,19 @@ class StockInfoQueryServiceImplTest {
             new StockFinancialResDTO.Row("매출 원가", List.of("10", "20", "30")),
             new StockFinancialResDTO.Row("매출 총 이익", List.of("40", "50", "60")),
             new StockFinancialResDTO.Row("당기순이익", List.of("70", "80", "90"))));
+  }
+
+  private StockFinancialResDTO.Financial shuffledFinancial() {
+    return new StockFinancialResDTO.Financial(
+        "005930",
+        "삼성전자",
+        StockFinancialStatement.INCOME,
+        StockFinancialPeriod.QUARTER,
+        "억원",
+        List.of("24년 9월", "24년 12월", "25년 3월"),
+        List.of(
+            new StockFinancialResDTO.Row("당기순이익", List.of("70", "80", "90")),
+            new StockFinancialResDTO.Row("매출 총 이익", List.of("40", "50", "60")),
+            new StockFinancialResDTO.Row("매출액", List.of("100", "200", "300"))));
   }
 }

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockInfoQueryServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockInfoQueryServiceImplTest.java
@@ -1,0 +1,90 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockChartResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockFinancialResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockInfoResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartInterval;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockChartType;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialPeriod;
+import com.example.elephantfinancelab_be.domain.stocks.entity.StockFinancialStatement;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StockInfoQueryServiceImplTest {
+
+  private final StockChartQueryService stockChartQueryService = mock(StockChartQueryService.class);
+  private final StockFinancialQueryService stockFinancialQueryService =
+      mock(StockFinancialQueryService.class);
+  private final StockInfoQueryServiceImpl service =
+      new StockInfoQueryServiceImpl(stockChartQueryService, stockFinancialQueryService);
+
+  @Test
+  void aggregatesPriceAndThreeIncomeRows() {
+    when(stockChartQueryService.getChart("005930", "1D", "LINE")).thenReturn(oneDayChart());
+    when(stockChartQueryService.getChart("005930", "1Y", "LINE")).thenReturn(oneYearChart());
+    when(stockFinancialQueryService.getFinancial("005930", "INCOME", "QUARTER"))
+        .thenReturn(financial());
+
+    StockInfoResDTO.Info result = service.getInfo("005930", "QUARTER").block();
+
+    assertThat(result.ticker()).isEqualTo("005930");
+    assertThat(result.nameKor()).isEqualTo("삼성전자");
+    assertThat(result.price().dayLowPriceKrw()).isEqualTo(69000L);
+    assertThat(result.price().dayHighPriceKrw()).isEqualTo(73000L);
+    assertThat(result.price().yearLowPriceKrw()).isEqualTo(58000L);
+    assertThat(result.price().yearHighPriceKrw()).isEqualTo(82000L);
+    assertThat(result.price().openPriceKrw()).isEqualTo(70000L);
+    assertThat(result.price().closePriceKrw()).isEqualTo(72500L);
+    assertThat(result.financialSummary().columns()).containsExactly("24년 9월", "24년 12월", "25년 3월");
+    assertThat(result.financialSummary().rows())
+        .extracting(StockInfoResDTO.Row::label)
+        .containsExactly("매출액", "매출 총 이익", "당기순이익");
+  }
+
+  private StockChartResDTO.Chart oneDayChart() {
+    return new StockChartResDTO.Chart(
+        "005930",
+        "1D",
+        StockChartType.LINE,
+        StockChartInterval.MINUTE,
+        "KRW",
+        List.of(
+            new StockChartResDTO.DataPoint(
+                "2026-05-22T09:00:00", 70000L, 70000L, 71000L, 69000L, 70500L, 1000L),
+            new StockChartResDTO.DataPoint(
+                "2026-05-22T15:30:00", 72500L, 70500L, 73000L, 70000L, 72500L, 2000L)));
+  }
+
+  private StockChartResDTO.Chart oneYearChart() {
+    return new StockChartResDTO.Chart(
+        "005930",
+        "1Y",
+        StockChartType.LINE,
+        StockChartInterval.DAY,
+        "KRW",
+        List.of(
+            new StockChartResDTO.DataPoint(
+                "2025-05-22", 61000L, 60000L, 62000L, 58000L, 61000L, 10000L),
+            new StockChartResDTO.DataPoint(
+                "2026-05-22", 72500L, 70000L, 82000L, 69000L, 72500L, 20000L)));
+  }
+
+  private StockFinancialResDTO.Financial financial() {
+    return new StockFinancialResDTO.Financial(
+        "005930",
+        "삼성전자",
+        StockFinancialStatement.INCOME,
+        StockFinancialPeriod.QUARTER,
+        "억원",
+        List.of("24년 9월", "24년 12월", "25년 3월"),
+        List.of(
+            new StockFinancialResDTO.Row("매출액", List.of("100", "200", "300")),
+            new StockFinancialResDTO.Row("매출 원가", List.of("10", "20", "30")),
+            new StockFinancialResDTO.Row("매출 총 이익", List.of("40", "50", "60")),
+            new StockFinancialResDTO.Row("당기순이익", List.of("70", "80", "90"))));
+  }
+}


### PR DESCRIPTION
## 💡 Issue
- Close #67

## 🏷️ Type
- [x] `feat`   : 새로운 기능 추가
- [ ] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [ ] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [ ] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- 종목 정보 탭에서 사용할 수 있는 집계 API 추가
- 기존 차트/재무 조회 API를 프론트에서 여러 번 조합하지 않아도 되도록, 백엔드에서 시세 요약과 주요 재무 데이터를 한 번에 내려주기 위해 수정


## 🛠️ Changes
- GET /api/stocks/{ticker}/info API 추가
- WebFlux Mono.zip을 사용해 1D 차트, 1Y 차트, 재무제표 데이터를 병렬로 조회하도록 구현
- 1D 차트 기준으로 1일 최저가, 1일 최고가, 시작가, 종가 계산
- 1Y 차트 기준으로 1년 최저가, 1년 최고가 계산
- 재무제표에서 매출액, 매출 총 이익, 당기순이익 3개 항목만 추려서 응답


## 📸 Screenshots
<img width="620" height="485" alt="스크린샷 2026-05-23 20 16 15" src="https://github.com/user-attachments/assets/4f60217e-fdd2-49cb-b006-cb7a90db443d" />


## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
- [x] 테스트(빌드)가 성공적으로 통과했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 주식 정보 조회 엔드포인트 추가: 특정 종목의 기본 정보, 가격 범위(일/연), 시가/종가, 재무 요약 데이터를 조회할 수 있습니다.

* **Tests**
  * 주식 정보 조회 기능에 대한 단위 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elephant-finance-lab/BE/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->