### PR TITLE
[FIX] 추천 캐시/자동매매 안전 게이트 보강

### DIFF
--- a/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/exception/code/AutoTradingErrorCode.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/exception/code/AutoTradingErrorCode.java
@@ -17,6 +17,8 @@ public enum AutoTradingErrorCode implements BaseErrorCode {
       HttpStatus.CONFLICT, "AUTO_TRADING409_01", "공용 모의계좌에서 이미 실행 중인 자동매매 세션이 있습니다."),
   SESSION_NOT_STOPPABLE(HttpStatus.CONFLICT, "AUTO_TRADING409_02", "현재 상태에서는 자동매매 세션을 중지할 수 없습니다."),
   AI_REQUEST_ID_NOT_FOUND(HttpStatus.CONFLICT, "AUTO_TRADING409_03", "AI 상태 조회에 필요한 요청 ID가 없습니다."),
+  READINESS_GATE_BLOCKED(
+      HttpStatus.CONFLICT, "AUTO_TRADING409_04", "AI 서비스 준비 상태가 자동매매 시작을 허용하지 않습니다."),
   AI_START_REJECTED(HttpStatus.BAD_GATEWAY, "AUTO_TRADING502_01", "AI 서버가 자동매매 시작 요청을 거부했습니다."),
   AI_STOP_REJECTED(HttpStatus.BAD_GATEWAY, "AUTO_TRADING502_02", "AI 서버가 자동매매 중지 요청을 거부했습니다.");
 

--- a/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.elephantfinancelab_be.domain.autotrading.service.command;
 
+import com.elephant.ai.v1.ServiceReadinessResponse;
 import com.elephant.ai.v1.StartPaperAutoTradingResponse;
 import com.elephant.ai.v1.StopPaperAutoTradingResponse;
 import com.example.elephantfinancelab_be.domain.autotrading.converter.AutoTradingConverter;
@@ -62,6 +63,7 @@ public class AutoTradingCommandServiceImpl implements AutoTradingCommandService 
     if (autoTradingSessionRepository.existsByActiveSlot(ACTIVE_SLOT)) {
       throw new AutoTradingException(AutoTradingErrorCode.ACTIVE_SESSION_EXISTS);
     }
+    requirePaperAutoReadiness();
 
     String aiRequestId = UUID.randomUUID().toString();
     AutoTradingSession session =
@@ -185,6 +187,17 @@ public class AutoTradingCommandServiceImpl implements AutoTradingCommandService 
         .map(String::trim)
         .distinct()
         .toList();
+  }
+
+  private void requirePaperAutoReadiness() {
+    ServiceReadinessResponse readiness = aiServerClient.getServiceReadiness(bundleId);
+    if (readiness == null
+        || !"PASS".equalsIgnoreCase(readiness.getStatus())
+        || !readiness.getSafeToEnableOrderActions()
+        || readiness.getLiveTradingAllowed()
+        || readiness.getSafeToEnableLiveActions()) {
+      throw new AutoTradingException(AutoTradingErrorCode.READINESS_GATE_BLOCKED);
+    }
   }
 
   private static String requireIdempotencyKey(String idempotencyKey) {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/converter/RecommendationConverter.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/converter/RecommendationConverter.java
@@ -19,6 +19,34 @@ public final class RecommendationConverter {
       String asof,
       String mode,
       List<RecommendationResDTO.RecommendationInfoDTO> infoList) {
+    return toRecommendationListDTO(
+        profile,
+        modelStatus,
+        modelReason,
+        generatedAt,
+        bundleId,
+        modelVersion,
+        asof,
+        mode,
+        null,
+        false,
+        null,
+        infoList);
+  }
+
+  public static RecommendationResDTO.RecommendationListDTO toRecommendationListDTO(
+      String profile,
+      String modelStatus,
+      String modelReason,
+      String generatedAt,
+      String bundleId,
+      String modelVersion,
+      String asof,
+      String mode,
+      Long cacheAgeSec,
+      Boolean stale,
+      String staleReason,
+      List<RecommendationResDTO.RecommendationInfoDTO> infoList) {
     return RecommendationResDTO.RecommendationListDTO.builder()
         .userProfileSummary(profile)
         .modelStatus(modelStatus)
@@ -28,6 +56,12 @@ public final class RecommendationConverter {
         .modelVersion(modelVersion)
         .asof(asof)
         .mode(mode)
+        .cacheAgeSec(cacheAgeSec)
+        .stale(stale)
+        .staleReason(staleReason)
+        .advisoryOnly(true)
+        .safeToEnableOrderActions(false)
+        .liveTradingAllowed(false)
         .recommendations(infoList)
         .build();
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/converter/RecommendationConverter.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/converter/RecommendationConverter.java
@@ -2,12 +2,23 @@ package com.example.elephantfinancelab_be.domain.recommendation.converter;
 
 import com.example.elephantfinancelab_be.domain.recommendation.dto.res.RecommendationResDTO;
 import com.example.elephantfinancelab_be.domain.recommendation.entity.Recommendation;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RecommendationConverter {
+
+  private static final DateTimeFormatter MODEL_GENERATED_AT_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+          .appendOffsetId()
+          .toFormatter();
 
   public static RecommendationResDTO.RecommendationListDTO toRecommendationListDTO(
       String profile,
@@ -117,7 +128,7 @@ public final class RecommendationConverter {
         .riskLevel(entity.getRiskLevel())
         .modelVersion(entity.getModelVersion())
         .bundleId(entity.getModelBundleId())
-        .modelGeneratedAt(entity.getModelGeneratedAt())
+        .modelGeneratedAt(formatGeneratedAt(entity.getModelGeneratedAt()))
         .modelAsof(entity.getModelAsof())
         .sections(
             RecommendationResDTO.DetailSectionsDTO.builder()
@@ -128,5 +139,9 @@ public final class RecommendationConverter {
                 .risk(entity.getRisk())
                 .build())
         .build();
+  }
+
+  private static String formatGeneratedAt(OffsetDateTime generatedAt) {
+    return generatedAt == null ? null : MODEL_GENERATED_AT_FORMATTER.format(generatedAt);
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/dto/res/RecommendationResDTO.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/dto/res/RecommendationResDTO.java
@@ -23,6 +23,12 @@ public class RecommendationResDTO {
     private String modelVersion;
     private String asof;
     private String mode;
+    private Long cacheAgeSec;
+    private Boolean stale;
+    private String staleReason;
+    private Boolean advisoryOnly;
+    private Boolean safeToEnableOrderActions;
+    private Boolean liveTradingAllowed;
     private List<RecommendationInfoDTO> recommendations;
   }
 

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/entity/Recommendation.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/entity/Recommendation.java
@@ -1,6 +1,7 @@
 package com.example.elephantfinancelab_be.domain.recommendation.entity;
 
 import jakarta.persistence.*;
+import java.time.OffsetDateTime;
 import lombok.*;
 
 @Entity
@@ -44,8 +45,8 @@ public class Recommendation {
   @Column(name = "model_bundle_id", length = 120)
   private String modelBundleId;
 
-  @Column(name = "model_generated_at", length = 50)
-  private String modelGeneratedAt;
+  @Column(name = "model_generated_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
+  private OffsetDateTime modelGeneratedAt;
 
   @Column(name = "model_asof", length = 50)
   private String modelAsof;
@@ -76,7 +77,7 @@ public class Recommendation {
       String riskLevel,
       String modelVersion,
       String modelBundleId,
-      String modelGeneratedAt,
+      OffsetDateTime modelGeneratedAt,
       String modelAsof) {
     this.modelRecommendationId = modelRecommendationId;
     if (stockName != null && !stockName.isBlank()) {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/repository/RecommendationRepository.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/repository/RecommendationRepository.java
@@ -9,4 +9,10 @@ public interface RecommendationRepository extends JpaRepository<Recommendation, 
   Optional<Recommendation> findByTickerCodeIgnoreCase(String tickerCode);
 
   List<Recommendation> findAllByOrderByRankingAsc();
+
+  Optional<Recommendation>
+      findFirstByModelGeneratedAtIsNotNullOrderByModelGeneratedAtDescRankingAsc();
+
+  List<Recommendation> findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+      String modelGeneratedAt, String modelBundleId);
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/repository/RecommendationRepository.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/repository/RecommendationRepository.java
@@ -10,8 +10,7 @@ public interface RecommendationRepository extends JpaRepository<Recommendation, 
 
   List<Recommendation> findAllByOrderByRankingAsc();
 
-  Optional<Recommendation>
-      findFirstByModelGeneratedAtIsNotNullOrderByModelGeneratedAtDescRankingAsc();
+  List<Recommendation> findByModelGeneratedAtIsNotNull();
 
   List<Recommendation> findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
       String modelGeneratedAt, String modelBundleId);

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/repository/RecommendationRepository.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/repository/RecommendationRepository.java
@@ -1,6 +1,7 @@
 package com.example.elephantfinancelab_be.domain.recommendation.repository;
 
 import com.example.elephantfinancelab_be.domain.recommendation.entity.Recommendation;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,5 +14,5 @@ public interface RecommendationRepository extends JpaRepository<Recommendation, 
   List<Recommendation> findByModelGeneratedAtIsNotNull();
 
   List<Recommendation> findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
-      String modelGeneratedAt, String modelBundleId);
+      OffsetDateTime modelGeneratedAt, String modelBundleId);
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/scheduler/RecommendationRefreshScheduler.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/scheduler/RecommendationRefreshScheduler.java
@@ -11,6 +11,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +43,8 @@ public class RecommendationRefreshScheduler {
 
   @Value("${ai.recommendations.refresh.market-holidays:}")
   private String marketHolidays;
+
+  private ParsedMarketSchedule parsedMarketSchedule;
 
   @Autowired
   public RecommendationRefreshScheduler(RecommendationQueryService recommendationQueryService) {
@@ -93,8 +96,9 @@ public class RecommendationRefreshScheduler {
       return false;
     }
 
-    LocalTime open = parseMarketTime(marketOpen);
-    LocalTime close = parseMarketTime(marketClose);
+    ParsedMarketSchedule schedule = parsedMarketSchedule();
+    LocalTime open = schedule.open();
+    LocalTime close = schedule.close();
     if (open == null || close == null || close.isBefore(open)) {
       return false;
     }
@@ -103,7 +107,28 @@ public class RecommendationRefreshScheduler {
     return !time.isBefore(open) && !time.isAfter(close);
   }
 
+  private ParsedMarketSchedule parsedMarketSchedule() {
+    ParsedMarketSchedule cached = parsedMarketSchedule;
+    if (cached != null && cached.matches(marketOpen, marketClose, marketHolidays)) {
+      return cached;
+    }
+
+    ParsedMarketSchedule parsed =
+        new ParsedMarketSchedule(
+            marketOpen,
+            marketClose,
+            marketHolidays,
+            parseMarketTime(marketOpen),
+            parseMarketTime(marketClose),
+            parseMarketHolidays(marketHolidays));
+    parsedMarketSchedule = parsed;
+    return parsed;
+  }
+
   private LocalTime parseMarketTime(String raw) {
+    if (raw == null) {
+      return null;
+    }
     try {
       return LocalTime.parse(raw);
     } catch (DateTimeParseException e) {
@@ -113,14 +138,19 @@ public class RecommendationRefreshScheduler {
   }
 
   private boolean isMarketHoliday(LocalDate date) {
-    Set<LocalDate> holidays =
-        Arrays.stream(marketHolidays.split(","))
-            .map(String::trim)
-            .filter(value -> !value.isBlank())
-            .map(this::parseMarketHoliday)
-            .filter(java.util.Objects::nonNull)
-            .collect(Collectors.toSet());
-    return holidays.contains(date);
+    return parsedMarketSchedule().holidays().contains(date);
+  }
+
+  private Set<LocalDate> parseMarketHolidays(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return Set.of();
+    }
+    return Arrays.stream(raw.split(","))
+        .map(String::trim)
+        .filter(value -> !value.isBlank())
+        .map(this::parseMarketHoliday)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
   }
 
   private LocalDate parseMarketHoliday(String raw) {
@@ -129,6 +159,21 @@ public class RecommendationRefreshScheduler {
     } catch (DateTimeParseException e) {
       log.warn("[RecommendationRefresh] Invalid market holiday config: {}", raw);
       return null;
+    }
+  }
+
+  private record ParsedMarketSchedule(
+      String marketOpen,
+      String marketClose,
+      String marketHolidays,
+      LocalTime open,
+      LocalTime close,
+      Set<LocalDate> holidays) {
+
+    private boolean matches(String marketOpen, String marketClose, String marketHolidays) {
+      return Objects.equals(this.marketOpen, marketOpen)
+          && Objects.equals(this.marketClose, marketClose)
+          && Objects.equals(this.marketHolidays, marketHolidays);
     }
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/scheduler/RecommendationRefreshScheduler.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/scheduler/RecommendationRefreshScheduler.java
@@ -1,0 +1,134 @@
+package com.example.elephantfinancelab_be.domain.recommendation.scheduler;
+
+import com.example.elephantfinancelab_be.domain.recommendation.dto.res.RecommendationResDTO;
+import com.example.elephantfinancelab_be.domain.recommendation.service.query.RecommendationQueryService;
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class RecommendationRefreshScheduler {
+
+  private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+  private final RecommendationQueryService recommendationQueryService;
+  private final Clock clock;
+
+  @Value("${ai.recommendations.refresh.enabled:false}")
+  private boolean refreshEnabled;
+
+  @Value("${ai.recommendations.refresh.market-hours-only:true}")
+  private boolean marketHoursOnly;
+
+  @Value("${ai.recommendations.refresh.market-open:09:00}")
+  private String marketOpen;
+
+  @Value("${ai.recommendations.refresh.market-close:15:30}")
+  private String marketClose;
+
+  @Value("${ai.recommendations.refresh.market-holidays:}")
+  private String marketHolidays;
+
+  @Autowired
+  public RecommendationRefreshScheduler(RecommendationQueryService recommendationQueryService) {
+    this(recommendationQueryService, Clock.system(KOREA_ZONE));
+  }
+
+  RecommendationRefreshScheduler(
+      RecommendationQueryService recommendationQueryService, Clock clock) {
+    this.recommendationQueryService = recommendationQueryService;
+    this.clock = clock;
+  }
+
+  @Scheduled(
+      fixedDelayString = "${ai.recommendations.refresh.fixed-delay-ms:60000}",
+      initialDelayString = "${ai.recommendations.refresh.initial-delay-ms:10000}")
+  public void refreshRecommendations() {
+    if (!refreshEnabled) {
+      return;
+    }
+
+    LocalDateTime now = ZonedDateTime.now(clock).withZoneSameInstant(KOREA_ZONE).toLocalDateTime();
+    if (!shouldRefreshAt(now)) {
+      return;
+    }
+
+    try {
+      RecommendationResDTO.RecommendationListDTO refreshed =
+          recommendationQueryService.refreshModelRecommendations();
+      int count =
+          refreshed.getRecommendations() == null ? 0 : refreshed.getRecommendations().size();
+      log.info(
+          "[RecommendationRefresh] AI recommendations refreshed: status={}, count={}, asof={}",
+          refreshed.getModelStatus(),
+          count,
+          refreshed.getAsof());
+    } catch (RuntimeException e) {
+      log.warn("[RecommendationRefresh] AI recommendation refresh skipped: {}", e.getMessage(), e);
+    }
+  }
+
+  boolean shouldRefreshAt(LocalDateTime now) {
+    if (!marketHoursOnly) {
+      return true;
+    }
+    if (now.getDayOfWeek() == DayOfWeek.SATURDAY || now.getDayOfWeek() == DayOfWeek.SUNDAY) {
+      return false;
+    }
+    if (isMarketHoliday(now.toLocalDate())) {
+      return false;
+    }
+
+    LocalTime open = parseMarketTime(marketOpen);
+    LocalTime close = parseMarketTime(marketClose);
+    if (open == null || close == null || close.isBefore(open)) {
+      return false;
+    }
+
+    LocalTime time = now.toLocalTime();
+    return !time.isBefore(open) && !time.isAfter(close);
+  }
+
+  private LocalTime parseMarketTime(String raw) {
+    try {
+      return LocalTime.parse(raw);
+    } catch (DateTimeParseException e) {
+      log.warn("[RecommendationRefresh] Invalid market time config: {}", raw);
+      return null;
+    }
+  }
+
+  private boolean isMarketHoliday(LocalDate date) {
+    Set<LocalDate> holidays =
+        Arrays.stream(marketHolidays.split(","))
+            .map(String::trim)
+            .filter(value -> !value.isBlank())
+            .map(this::parseMarketHoliday)
+            .filter(java.util.Objects::nonNull)
+            .collect(Collectors.toSet());
+    return holidays.contains(date);
+  }
+
+  private LocalDate parseMarketHoliday(String raw) {
+    try {
+      return LocalDate.parse(raw);
+    } catch (DateTimeParseException e) {
+      log.warn("[RecommendationRefresh] Invalid market holiday config: {}", raw);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryService.java
@@ -5,6 +5,8 @@ import com.example.elephantfinancelab_be.domain.recommendation.dto.res.Recommend
 public interface RecommendationQueryService {
   RecommendationResDTO.RecommendationListDTO findRecommendationList();
 
+  RecommendationResDTO.RecommendationListDTO refreshModelRecommendations();
+
   RecommendationResDTO.RecommendationDetailDTO findRecommendationDetail(Long recommendationId);
 
   RecommendationResDTO.RecommendationDetailDTO findRecommendationDetail(String stockCode);

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImpl.java
@@ -53,6 +53,9 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
   @Value("${ai.recommendations.cache.max-age-seconds:180}")
   private long cacheMaxAgeSeconds;
 
+  @Value("${ai.recommendations.cache.max-future-skew-seconds:5}")
+  private long cacheMaxFutureSkewSeconds;
+
   private Clock clock = Clock.systemUTC();
 
   @Override
@@ -100,12 +103,7 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
   }
 
   private RecommendationResDTO.RecommendationListDTO findCachedRecommendationList() {
-    Recommendation latest =
-        recommendationRepository
-            .findFirstByModelGeneratedAtIsNotNullOrderByModelGeneratedAtDescRankingAsc()
-            .orElseThrow(
-                () ->
-                    new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE));
+    Recommendation latest = findLatestCachedRecommendation();
     long cacheAgeSec = cacheAgeSec(latest.getModelGeneratedAt());
     if (cacheAgeSec > cacheMaxAgeSeconds) {
       log.warn(
@@ -217,10 +215,36 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
   }
 
   private long cacheAgeSec(String generatedAt) {
+    OffsetDateTime generated = parseGeneratedAt(generatedAt);
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    if (generated.toInstant().isAfter(now.plusSeconds(cacheMaxFutureSkewSeconds).toInstant())) {
+      log.warn(
+          "[Recommendation] cached model recommendations have future generatedAt={}, maxFutureSkewSec={}",
+          generatedAt,
+          cacheMaxFutureSkewSeconds);
+      throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
+    }
+    long ageSec = Duration.between(generated, now).getSeconds();
+    return Math.max(0L, ageSec);
+  }
+
+  private Recommendation findLatestCachedRecommendation() {
+    return recommendationRepository.findByModelGeneratedAtIsNotNull().stream()
+        .sorted(
+            Comparator.comparing(
+                    (Recommendation recommendation) ->
+                        parseGeneratedAt(recommendation.getModelGeneratedAt()).toInstant())
+                .reversed()
+                .thenComparing(
+                    Recommendation::getRanking, Comparator.nullsLast(Comparator.naturalOrder())))
+        .findFirst()
+        .orElseThrow(
+            () -> new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE));
+  }
+
+  private OffsetDateTime parseGeneratedAt(String generatedAt) {
     try {
-      OffsetDateTime generated = OffsetDateTime.parse(generatedAt);
-      long ageSec = Duration.between(generated, OffsetDateTime.now(clock)).getSeconds();
-      return Math.max(0L, ageSec);
+      return OffsetDateTime.parse(generatedAt);
     } catch (DateTimeParseException | NullPointerException e) {
       log.warn(
           "[Recommendation] cached model recommendations have invalid generatedAt={}", generatedAt);

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImpl.java
@@ -13,6 +13,10 @@ import com.example.elephantfinancelab_be.domain.user.exception.code.UserErrorCod
 import com.example.elephantfinancelab_be.domain.user.repository.UserRepository;
 import com.example.elephantfinancelab_be.global.apiPayload.exception.GeneralException;
 import com.example.elephantfinancelab_be.global.config.AiServerClient;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -43,9 +47,26 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
   @Value("${ai.recommendations.include-diagnostics:false}")
   private boolean includeRecommendationDiagnostics;
 
+  @Value("${ai.recommendations.cache-read-enabled:false}")
+  private boolean cacheReadEnabled;
+
+  @Value("${ai.recommendations.cache.max-age-seconds:180}")
+  private long cacheMaxAgeSeconds;
+
+  private Clock clock = Clock.systemUTC();
+
   @Override
   @Transactional
   public RecommendationResDTO.RecommendationListDTO findRecommendationList() {
+    if (cacheReadEnabled) {
+      return findCachedRecommendationList();
+    }
+    return refreshModelRecommendations();
+  }
+
+  @Override
+  @Transactional
+  public RecommendationResDTO.RecommendationListDTO refreshModelRecommendations() {
     GetRecommendationsResponse response =
         aiServerClient.getRecommendations(
             recommendationBundleId, recommendationTopK, includeRecommendationDiagnostics);
@@ -75,6 +96,48 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
         response.getModelVersion(),
         response.getAsof(),
         response.getMode(),
+        infoList);
+  }
+
+  private RecommendationResDTO.RecommendationListDTO findCachedRecommendationList() {
+    Recommendation latest =
+        recommendationRepository
+            .findFirstByModelGeneratedAtIsNotNullOrderByModelGeneratedAtDescRankingAsc()
+            .orElseThrow(
+                () ->
+                    new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE));
+    long cacheAgeSec = cacheAgeSec(latest.getModelGeneratedAt());
+    if (cacheAgeSec > cacheMaxAgeSeconds) {
+      log.warn(
+          "[Recommendation] cached model recommendations stale: generatedAt={}, ageSec={}, maxAgeSec={}",
+          latest.getModelGeneratedAt(),
+          cacheAgeSec,
+          cacheMaxAgeSeconds);
+      throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
+    }
+    List<Recommendation> savedRecommendations =
+        recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            latest.getModelGeneratedAt(), latest.getModelBundleId());
+    if (savedRecommendations.isEmpty()) {
+      log.warn("[Recommendation] cached model recommendations unavailable");
+      throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
+    }
+    List<RecommendationResDTO.RecommendationInfoDTO> infoList =
+        savedRecommendations.stream()
+            .map(RecommendationConverter::toRecommendationInfoDTO)
+            .toList();
+    return RecommendationConverter.toRecommendationListDTO(
+        "사용자 맞춤 투자 추천 리스트",
+        "PASS",
+        "cached_recommendations",
+        latest.getModelGeneratedAt(),
+        latest.getModelBundleId(),
+        latest.getModelVersion(),
+        latest.getModelAsof(),
+        "cached",
+        cacheAgeSec,
+        false,
+        null,
         infoList);
   }
 
@@ -151,5 +214,17 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
       throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
     }
     return stockCode.toUpperCase(Locale.ROOT);
+  }
+
+  private long cacheAgeSec(String generatedAt) {
+    try {
+      OffsetDateTime generated = OffsetDateTime.parse(generatedAt);
+      long ageSec = Duration.between(generated, OffsetDateTime.now(clock)).getSeconds();
+      return Math.max(0L, ageSec);
+    } catch (DateTimeParseException | NullPointerException e) {
+      log.warn(
+          "[Recommendation] cached model recommendations have invalid generatedAt={}", generatedAt);
+      throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
+    }
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImpl.java
@@ -16,7 +16,10 @@ import com.example.elephantfinancelab_be.global.config.AiServerClient;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -33,6 +36,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RecommendationQueryServiceImpl implements RecommendationQueryService {
+
+  private static final DateTimeFormatter MODEL_GENERATED_AT_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+          .appendOffsetId()
+          .toFormatter();
 
   private final RecommendationRepository recommendationRepository;
   private final UserRepository userRepository;
@@ -81,9 +91,10 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
       throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
     }
 
+    OffsetDateTime modelGeneratedAt = parseGeneratedAt(response.getGeneratedAt());
     List<Recommendation> recommendations =
         deduplicateByStockCode(response).values().stream()
-            .map(item -> upsertModelRecommendation(item, response))
+            .map(item -> upsertModelRecommendation(item, response, modelGeneratedAt))
             .toList();
     List<Recommendation> savedRecommendations = recommendationRepository.saveAll(recommendations);
     List<RecommendationResDTO.RecommendationInfoDTO> infoList =
@@ -94,7 +105,7 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
         "사용자 맞춤 투자 추천 리스트",
         response.getStatus(),
         response.getReason(),
-        response.getGeneratedAt(),
+        formatGeneratedAt(modelGeneratedAt),
         response.getBundleId(),
         response.getModelVersion(),
         response.getAsof(),
@@ -104,18 +115,19 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
 
   private RecommendationResDTO.RecommendationListDTO findCachedRecommendationList() {
     Recommendation latest = findLatestCachedRecommendation();
-    long cacheAgeSec = cacheAgeSec(latest.getModelGeneratedAt());
+    OffsetDateTime latestGeneratedAt = latest.getModelGeneratedAt();
+    long cacheAgeSec = cacheAgeSec(latestGeneratedAt);
     if (cacheAgeSec > cacheMaxAgeSeconds) {
       log.warn(
           "[Recommendation] cached model recommendations stale: generatedAt={}, ageSec={}, maxAgeSec={}",
-          latest.getModelGeneratedAt(),
+          formatGeneratedAt(latestGeneratedAt),
           cacheAgeSec,
           cacheMaxAgeSeconds);
       throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
     }
     List<Recommendation> savedRecommendations =
         recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
-            latest.getModelGeneratedAt(), latest.getModelBundleId());
+            latestGeneratedAt, latest.getModelBundleId());
     if (savedRecommendations.isEmpty()) {
       log.warn("[Recommendation] cached model recommendations unavailable");
       throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
@@ -128,7 +140,7 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
         "사용자 맞춤 투자 추천 리스트",
         "PASS",
         "cached_recommendations",
-        latest.getModelGeneratedAt(),
+        formatGeneratedAt(latestGeneratedAt),
         latest.getModelBundleId(),
         latest.getModelVersion(),
         latest.getModelAsof(),
@@ -183,7 +195,9 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
   }
 
   private Recommendation upsertModelRecommendation(
-      RecommendationItem item, GetRecommendationsResponse response) {
+      RecommendationItem item,
+      GetRecommendationsResponse response,
+      OffsetDateTime modelGeneratedAt) {
     String stockCode = normalizedStockCode(item);
     Recommendation recommendation =
         recommendationRepository
@@ -200,7 +214,7 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
         item.getRiskLevel(),
         item.getModelVersion().isBlank() ? response.getModelVersion() : item.getModelVersion(),
         item.getBundleId().isBlank() ? response.getBundleId() : item.getBundleId(),
-        response.getGeneratedAt(),
+        modelGeneratedAt,
         response.getAsof());
     return recommendation;
   }
@@ -214,13 +228,15 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
     return stockCode.toUpperCase(Locale.ROOT);
   }
 
-  private long cacheAgeSec(String generatedAt) {
-    OffsetDateTime generated = parseGeneratedAt(generatedAt);
+  private long cacheAgeSec(OffsetDateTime generated) {
+    if (generated == null) {
+      throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
+    }
     OffsetDateTime now = OffsetDateTime.now(clock);
     if (generated.toInstant().isAfter(now.plusSeconds(cacheMaxFutureSkewSeconds).toInstant())) {
       log.warn(
           "[Recommendation] cached model recommendations have future generatedAt={}, maxFutureSkewSec={}",
-          generatedAt,
+          formatGeneratedAt(generated),
           cacheMaxFutureSkewSeconds);
       throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
     }
@@ -233,7 +249,7 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
         .sorted(
             Comparator.comparing(
                     (Recommendation recommendation) ->
-                        parseGeneratedAt(recommendation.getModelGeneratedAt()).toInstant())
+                        recommendation.getModelGeneratedAt().toInstant())
                 .reversed()
                 .thenComparing(
                     Recommendation::getRanking, Comparator.nullsLast(Comparator.naturalOrder())))
@@ -246,9 +262,12 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
     try {
       return OffsetDateTime.parse(generatedAt);
     } catch (DateTimeParseException | NullPointerException e) {
-      log.warn(
-          "[Recommendation] cached model recommendations have invalid generatedAt={}", generatedAt);
+      log.warn("[Recommendation] AI model response has invalid generatedAt={}", generatedAt);
       throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
     }
+  }
+
+  private String formatGeneratedAt(OffsetDateTime generatedAt) {
+    return generatedAt == null ? null : MODEL_GENERATED_AT_FORMATTER.format(generatedAt);
   }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -86,6 +86,7 @@ ai:
     cache-read-enabled: ${AI_RECOMMENDATION_CACHE_READ_ENABLED:false}
     cache:
       max-age-seconds: ${AI_RECOMMENDATION_CACHE_MAX_AGE_SECONDS:180}
+      max-future-skew-seconds: ${AI_RECOMMENDATION_CACHE_MAX_FUTURE_SKEW_SECONDS:5}
     refresh:
       enabled: ${AI_RECOMMENDATION_REFRESH_ENABLED:false}
       fixed-delay-ms: ${AI_RECOMMENDATION_REFRESH_FIXED_DELAY_MS:60000}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -83,6 +83,17 @@ ai:
     bundle-id: ${AI_RECOMMENDATION_BUNDLE_ID:}
     top-k: ${AI_RECOMMENDATION_TOP_K:10}
     include-diagnostics: ${AI_RECOMMENDATION_INCLUDE_DIAGNOSTICS:false}
+    cache-read-enabled: ${AI_RECOMMENDATION_CACHE_READ_ENABLED:false}
+    cache:
+      max-age-seconds: ${AI_RECOMMENDATION_CACHE_MAX_AGE_SECONDS:180}
+    refresh:
+      enabled: ${AI_RECOMMENDATION_REFRESH_ENABLED:false}
+      fixed-delay-ms: ${AI_RECOMMENDATION_REFRESH_FIXED_DELAY_MS:60000}
+      initial-delay-ms: ${AI_RECOMMENDATION_REFRESH_INITIAL_DELAY_MS:10000}
+      market-hours-only: ${AI_RECOMMENDATION_REFRESH_MARKET_HOURS_ONLY:true}
+      market-open: ${AI_RECOMMENDATION_REFRESH_MARKET_OPEN:09:00}
+      market-close: ${AI_RECOMMENDATION_REFRESH_MARKET_CLOSE:15:30}
+      market-holidays: ${AI_RECOMMENDATION_REFRESH_MARKET_HOLIDAYS:2026-06-03,2026-07-17}
 
 auto-trading:
   kafka:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -125,6 +125,7 @@ ai:
     cache-read-enabled: ${AI_RECOMMENDATION_CACHE_READ_ENABLED:false}
     cache:
       max-age-seconds: ${AI_RECOMMENDATION_CACHE_MAX_AGE_SECONDS:180}
+      max-future-skew-seconds: ${AI_RECOMMENDATION_CACHE_MAX_FUTURE_SKEW_SECONDS:5}
     refresh:
       enabled: ${AI_RECOMMENDATION_REFRESH_ENABLED:false}
       fixed-delay-ms: ${AI_RECOMMENDATION_REFRESH_FIXED_DELAY_MS:60000}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -122,6 +122,17 @@ ai:
     bundle-id: ${AI_RECOMMENDATION_BUNDLE_ID:}
     top-k: ${AI_RECOMMENDATION_TOP_K:10}
     include-diagnostics: ${AI_RECOMMENDATION_INCLUDE_DIAGNOSTICS:false}
+    cache-read-enabled: ${AI_RECOMMENDATION_CACHE_READ_ENABLED:false}
+    cache:
+      max-age-seconds: ${AI_RECOMMENDATION_CACHE_MAX_AGE_SECONDS:180}
+    refresh:
+      enabled: ${AI_RECOMMENDATION_REFRESH_ENABLED:false}
+      fixed-delay-ms: ${AI_RECOMMENDATION_REFRESH_FIXED_DELAY_MS:60000}
+      initial-delay-ms: ${AI_RECOMMENDATION_REFRESH_INITIAL_DELAY_MS:10000}
+      market-hours-only: ${AI_RECOMMENDATION_REFRESH_MARKET_HOURS_ONLY:true}
+      market-open: ${AI_RECOMMENDATION_REFRESH_MARKET_OPEN:09:00}
+      market-close: ${AI_RECOMMENDATION_REFRESH_MARKET_CLOSE:15:30}
+      market-holidays: ${AI_RECOMMENDATION_REFRESH_MARKET_HOLIDAYS:2026-06-03,2026-07-17}
 
 auto-trading:
   kafka:

--- a/src/test/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.elephant.ai.v1.ServiceReadinessResponse;
 import com.elephant.ai.v1.StartPaperAutoTradingResponse;
 import com.elephant.ai.v1.StopPaperAutoTradingResponse;
 import com.example.elephantfinancelab_be.domain.autotrading.dto.req.AutoTradingReqDTO;
@@ -57,6 +58,7 @@ class AutoTradingCommandServiceImplTest {
     when(sessionRepository.existsByActiveSlot(anyString())).thenReturn(false);
     when(selectedRepository.findAllByUserIdAndRecommendation_IdIn(1L, List.of(1L)))
         .thenReturn(List.of(selectedRecommendation(1L, "005930")));
+    when(aiServerClient.getServiceReadiness("BUNDLE-TEST")).thenReturn(paperReady());
     when(aiServerClient.startPaperAutoTrading(
             anyString(), anyString(), any(), any(), any(), anyString()))
         .thenReturn(
@@ -105,6 +107,7 @@ class AutoTradingCommandServiceImplTest {
     when(sessionRepository.existsByActiveSlot(anyString())).thenReturn(false);
     when(selectedRepository.findAllByUserIdAndRecommendation_IdIn(1L, List.of(1L)))
         .thenReturn(List.of(selectedRecommendation(1L, "005930")));
+    when(aiServerClient.getServiceReadiness("BUNDLE-TEST")).thenReturn(paperReady());
     when(aiServerClient.startPaperAutoTrading(
             anyString(), anyString(), any(), any(), any(), anyString()))
         .thenThrow(new AiServerException(AiServerErrorCode.AI503_01));
@@ -117,6 +120,61 @@ class AutoTradingCommandServiceImplTest {
     verify(sessionRepository, times(2)).saveAndFlush(sessionCaptor.capture());
     assertThat(sessionCaptor.getAllValues().getLast().getStatus())
         .isEqualTo(AutoTradingSessionStatus.FAILED);
+  }
+
+  @Test
+  void blocksStartBeforeAiCallWhenReadinessDisallowsOrderActions() {
+    when(sessionRepository.findByUserIdAndIdempotencyKey(1L, "idempotency-1"))
+        .thenReturn(Optional.empty());
+    when(sessionRepository.existsByActiveSlot(anyString())).thenReturn(false);
+    when(selectedRepository.findAllByUserIdAndRecommendation_IdIn(1L, List.of(1L)))
+        .thenReturn(List.of(selectedRecommendation(1L, "005930")));
+    when(aiServerClient.getServiceReadiness("BUNDLE-TEST"))
+        .thenReturn(
+            ServiceReadinessResponse.newBuilder()
+                .setStatus("PASS")
+                .setSafeToEnableOrderActions(false)
+                .setLiveTradingAllowed(false)
+                .setSafeToEnableLiveActions(false)
+                .build());
+
+    assertThatThrownBy(() -> service.startSession(1L, "idempotency-1", request()))
+        .isInstanceOf(AutoTradingException.class)
+        .satisfies(
+            exception ->
+                assertThat(((AutoTradingException) exception).getCode())
+                    .isEqualTo(AutoTradingErrorCode.READINESS_GATE_BLOCKED));
+
+    verify(aiServerClient, never())
+        .startPaperAutoTrading(anyString(), anyString(), any(), any(), any(), anyString());
+    verify(sessionRepository, never()).saveAndFlush(any(AutoTradingSession.class));
+  }
+
+  @Test
+  void blocksPaperStartWhenReadinessIndicatesLiveActions() {
+    when(sessionRepository.findByUserIdAndIdempotencyKey(1L, "idempotency-1"))
+        .thenReturn(Optional.empty());
+    when(sessionRepository.existsByActiveSlot(anyString())).thenReturn(false);
+    when(selectedRepository.findAllByUserIdAndRecommendation_IdIn(1L, List.of(1L)))
+        .thenReturn(List.of(selectedRecommendation(1L, "005930")));
+    when(aiServerClient.getServiceReadiness("BUNDLE-TEST"))
+        .thenReturn(
+            ServiceReadinessResponse.newBuilder()
+                .setStatus("PASS")
+                .setSafeToEnableOrderActions(true)
+                .setLiveTradingAllowed(true)
+                .setSafeToEnableLiveActions(true)
+                .build());
+
+    assertThatThrownBy(() -> service.startSession(1L, "idempotency-1", request()))
+        .isInstanceOf(AutoTradingException.class)
+        .satisfies(
+            exception ->
+                assertThat(((AutoTradingException) exception).getCode())
+                    .isEqualTo(AutoTradingErrorCode.READINESS_GATE_BLOCKED));
+
+    verify(aiServerClient, never())
+        .startPaperAutoTrading(anyString(), anyString(), any(), any(), any(), anyString());
   }
 
   @Test
@@ -179,5 +237,14 @@ class AutoTradingCommandServiceImplTest {
   private static UserSelectedRecommendation selectedRecommendation(Long id, String ticker) {
     Recommendation recommendation = Recommendation.builder().id(id).tickerCode(ticker).build();
     return UserSelectedRecommendation.builder().userId(1L).recommendation(recommendation).build();
+  }
+
+  private static ServiceReadinessResponse paperReady() {
+    return ServiceReadinessResponse.newBuilder()
+        .setStatus("PASS")
+        .setSafeToEnableOrderActions(true)
+        .setLiveTradingAllowed(false)
+        .setSafeToEnableLiveActions(false)
+        .build();
   }
 }

--- a/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/scheduler/RecommendationRefreshSchedulerTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/scheduler/RecommendationRefreshSchedulerTest.java
@@ -79,6 +79,22 @@ class RecommendationRefreshSchedulerTest {
   }
 
   @Test
+  void reparsesMarketConfigWhenSettingsChange() {
+    ReflectionTestUtils.setField(scheduler, "marketHoursOnly", true);
+    ReflectionTestUtils.setField(scheduler, "marketOpen", "10:30");
+    ReflectionTestUtils.setField(scheduler, "marketClose", "15:30");
+    ReflectionTestUtils.setField(scheduler, "marketHolidays", "2026-06-03");
+
+    assertThat(scheduler.shouldRefreshAt(LocalDateTime.of(2026, 6, 1, 10, 0))).isFalse();
+
+    ReflectionTestUtils.setField(scheduler, "marketOpen", "09:00");
+    ReflectionTestUtils.setField(scheduler, "marketHolidays", "2026-06-04");
+
+    assertThat(scheduler.shouldRefreshAt(LocalDateTime.of(2026, 6, 1, 10, 0))).isTrue();
+    assertThat(scheduler.shouldRefreshAt(LocalDateTime.of(2026, 6, 3, 10, 0))).isTrue();
+  }
+
+  @Test
   void swallowRefreshFailureSoSchedulerKeepsRunning() {
     ReflectionTestUtils.setField(scheduler, "refreshEnabled", true);
     ReflectionTestUtils.setField(scheduler, "marketHoursOnly", true);

--- a/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/scheduler/RecommendationRefreshSchedulerTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/scheduler/RecommendationRefreshSchedulerTest.java
@@ -1,0 +1,118 @@
+package com.example.elephantfinancelab_be.domain.recommendation.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.example.elephantfinancelab_be.domain.recommendation.dto.res.RecommendationResDTO;
+import com.example.elephantfinancelab_be.domain.recommendation.service.query.RecommendationQueryService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RecommendationRefreshSchedulerTest {
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  private final RecommendationQueryService recommendationQueryService =
+      mock(RecommendationQueryService.class);
+  private final RecommendationRefreshScheduler scheduler =
+      new RecommendationRefreshScheduler(
+          recommendationQueryService, Clock.fixed(Instant.parse("2026-06-01T01:00:00Z"), KST));
+
+  @Test
+  void doesNothingWhenRefreshDisabled() {
+    ReflectionTestUtils.setField(scheduler, "refreshEnabled", false);
+
+    scheduler.refreshRecommendations();
+
+    verifyNoInteractions(recommendationQueryService);
+  }
+
+  @Test
+  void refreshesDuringConfiguredMarketHours() {
+    ReflectionTestUtils.setField(scheduler, "refreshEnabled", true);
+    ReflectionTestUtils.setField(scheduler, "marketHoursOnly", true);
+    ReflectionTestUtils.setField(scheduler, "marketOpen", "09:00");
+    ReflectionTestUtils.setField(scheduler, "marketClose", "15:30");
+    ReflectionTestUtils.setField(scheduler, "marketHolidays", "2026-06-03,2026-07-17");
+
+    scheduler.refreshRecommendations();
+
+    verify(recommendationQueryService).refreshModelRecommendations();
+  }
+
+  @Test
+  void skipsOutsideMarketHours() {
+    ReflectionTestUtils.setField(scheduler, "refreshEnabled", true);
+    ReflectionTestUtils.setField(scheduler, "marketHoursOnly", true);
+    ReflectionTestUtils.setField(scheduler, "marketOpen", "10:30");
+    ReflectionTestUtils.setField(scheduler, "marketClose", "15:30");
+    ReflectionTestUtils.setField(scheduler, "marketHolidays", "2026-06-03,2026-07-17");
+
+    scheduler.refreshRecommendations();
+
+    verifyNoInteractions(recommendationQueryService);
+  }
+
+  @Test
+  void canDisableMarketHourFilterForManualRuns() {
+    ReflectionTestUtils.setField(scheduler, "marketHoursOnly", false);
+
+    assertThat(scheduler.shouldRefreshAt(LocalDateTime.of(2026, 6, 6, 1, 0))).isTrue();
+  }
+
+  @Test
+  void skipsConfiguredMarketHoliday() {
+    ReflectionTestUtils.setField(scheduler, "marketHoursOnly", true);
+    ReflectionTestUtils.setField(scheduler, "marketOpen", "09:00");
+    ReflectionTestUtils.setField(scheduler, "marketClose", "15:30");
+    ReflectionTestUtils.setField(scheduler, "marketHolidays", "2026-06-03,2026-07-17");
+
+    assertThat(scheduler.shouldRefreshAt(LocalDateTime.of(2026, 6, 3, 10, 0))).isFalse();
+  }
+
+  @Test
+  void swallowRefreshFailureSoSchedulerKeepsRunning() {
+    ReflectionTestUtils.setField(scheduler, "refreshEnabled", true);
+    ReflectionTestUtils.setField(scheduler, "marketHoursOnly", true);
+    ReflectionTestUtils.setField(scheduler, "marketOpen", "09:00");
+    ReflectionTestUtils.setField(scheduler, "marketClose", "15:30");
+    ReflectionTestUtils.setField(scheduler, "marketHolidays", "2026-06-03,2026-07-17");
+    doThrow(new IllegalStateException("ai down"))
+        .when(recommendationQueryService)
+        .refreshModelRecommendations();
+
+    scheduler.refreshRecommendations();
+
+    verify(recommendationQueryService).refreshModelRecommendations();
+  }
+
+  @Test
+  void logsRefreshedRecommendationCountWhenServiceReturnsPayload() {
+    ReflectionTestUtils.setField(scheduler, "refreshEnabled", true);
+    ReflectionTestUtils.setField(scheduler, "marketHoursOnly", true);
+    ReflectionTestUtils.setField(scheduler, "marketOpen", "09:00");
+    ReflectionTestUtils.setField(scheduler, "marketClose", "15:30");
+    ReflectionTestUtils.setField(scheduler, "marketHolidays", "2026-06-03,2026-07-17");
+    RecommendationResDTO.RecommendationInfoDTO item =
+        RecommendationResDTO.RecommendationInfoDTO.builder().stockCode("005930").build();
+    org.mockito.Mockito.when(recommendationQueryService.refreshModelRecommendations())
+        .thenReturn(
+            RecommendationResDTO.RecommendationListDTO.builder()
+                .modelStatus("PASS")
+                .asof("2026-06-01T10:00:00+09:00")
+                .recommendations(List.of(item))
+                .build());
+
+    scheduler.refreshRecommendations();
+
+    verify(recommendationQueryService).refreshModelRecommendations();
+  }
+}

--- a/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImplTest.java
@@ -3,7 +3,9 @@ package com.example.elephantfinancelab_be.domain.recommendation.service.query;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.elephant.ai.v1.GetRecommendationsResponse;
@@ -15,6 +17,10 @@ import com.example.elephantfinancelab_be.domain.recommendation.repository.Recomm
 import com.example.elephantfinancelab_be.domain.user.repository.UserRepository;
 import com.example.elephantfinancelab_be.global.apiPayload.exception.GeneralException;
 import com.example.elephantfinancelab_be.global.config.AiServerClient;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,6 +40,10 @@ class RecommendationQueryServiceImplTest {
     ReflectionTestUtils.setField(service, "recommendationBundleId", "BUNDLE-TEST");
     ReflectionTestUtils.setField(service, "recommendationTopK", 10);
     ReflectionTestUtils.setField(service, "includeRecommendationDiagnostics", false);
+    ReflectionTestUtils.setField(service, "cacheReadEnabled", false);
+    ReflectionTestUtils.setField(service, "cacheMaxAgeSeconds", 180L);
+    ReflectionTestUtils.setField(
+        service, "clock", Clock.fixed(Instant.parse("2026-06-01T01:01:00Z"), ZoneOffset.UTC));
   }
 
   @Test
@@ -97,6 +107,123 @@ class RecommendationQueryServiceImplTest {
     assertThat(existing.getCompanyName()).isEqualTo("삼성전자");
     verify(aiServerClient).getRecommendations("BUNDLE-TEST", 10, false);
     verify(recommendationRepository).saveAll(org.mockito.ArgumentMatchers.anyList());
+  }
+
+  @Test
+  void readsCachedRecommendationsWithoutCallingAiWhenCacheReadEnabled() {
+    ReflectionTestUtils.setField(service, "cacheReadEnabled", true);
+    Recommendation cached =
+        Recommendation.builder()
+            .id(1L)
+            .tickerCode("005930")
+            .companyName("삼성전자")
+            .ranking(1)
+            .score(0.92)
+            .modelRecommendationId("MODEL-1")
+            .modelBundleId("BUNDLE-TEST")
+            .modelVersion("v2")
+            .modelGeneratedAt("2026-06-01T10:00:00+09:00")
+            .modelAsof("2026-06-01T09:59:00+09:00")
+            .riskLevel("low")
+            .build();
+    when(recommendationRepository
+            .findFirstByModelGeneratedAtIsNotNullOrderByModelGeneratedAtDescRankingAsc())
+        .thenReturn(Optional.of(cached));
+    when(recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            "2026-06-01T10:00:00+09:00", "BUNDLE-TEST"))
+        .thenReturn(List.of(cached));
+
+    RecommendationResDTO.RecommendationListDTO result = service.findRecommendationList();
+
+    assertThat(result.getModelStatus()).isEqualTo("PASS");
+    assertThat(result.getModelReason()).isEqualTo("cached_recommendations");
+    assertThat(result.getMode()).isEqualTo("cached");
+    assertThat(result.getCacheAgeSec()).isEqualTo(60L);
+    assertThat(result.getStale()).isFalse();
+    assertThat(result.getAdvisoryOnly()).isTrue();
+    assertThat(result.getSafeToEnableOrderActions()).isFalse();
+    assertThat(result.getLiveTradingAllowed()).isFalse();
+    assertThat(result.getRecommendations())
+        .extracting(RecommendationResDTO.RecommendationInfoDTO::getStockCode)
+        .containsExactly("005930");
+    verify(recommendationRepository)
+        .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            "2026-06-01T10:00:00+09:00", "BUNDLE-TEST");
+    verifyNoInteractions(aiServerClient);
+  }
+
+  @Test
+  void readsOnlyLatestCachedRecommendationBatch() {
+    ReflectionTestUtils.setField(service, "cacheReadEnabled", true);
+    Recommendation latest =
+        Recommendation.builder()
+            .id(1L)
+            .tickerCode("005930")
+            .companyName("삼성전자")
+            .ranking(1)
+            .score(0.92)
+            .modelRecommendationId("MODEL-1")
+            .modelBundleId("BUNDLE-LATEST")
+            .modelVersion("v2")
+            .modelGeneratedAt("2026-06-01T10:00:00+09:00")
+            .modelAsof("2026-06-01T09:59:00+09:00")
+            .riskLevel("low")
+            .build();
+    Recommendation old =
+        Recommendation.builder()
+            .id(2L)
+            .tickerCode("000660")
+            .companyName("SK하이닉스")
+            .ranking(2)
+            .score(0.81)
+            .modelBundleId("BUNDLE-OLD")
+            .modelGeneratedAt("2026-06-01T09:55:00+09:00")
+            .modelAsof("2026-06-01T09:54:00+09:00")
+            .build();
+    when(recommendationRepository
+            .findFirstByModelGeneratedAtIsNotNullOrderByModelGeneratedAtDescRankingAsc())
+        .thenReturn(Optional.of(latest));
+    when(recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            "2026-06-01T10:00:00+09:00", "BUNDLE-LATEST"))
+        .thenReturn(List.of(latest));
+
+    RecommendationResDTO.RecommendationListDTO result = service.findRecommendationList();
+
+    assertThat(result.getBundleId()).isEqualTo("BUNDLE-LATEST");
+    assertThat(result.getRecommendations())
+        .extracting(RecommendationResDTO.RecommendationInfoDTO::getStockCode)
+        .containsExactly("005930");
+    assertThat(result.getRecommendations())
+        .extracting(RecommendationResDTO.RecommendationInfoDTO::getStockCode)
+        .doesNotContain(old.getTickerCode());
+  }
+
+  @Test
+  void rejectsStaleCachedRecommendationsBeforeReturningRows() {
+    ReflectionTestUtils.setField(service, "cacheReadEnabled", true);
+    Recommendation stale =
+        Recommendation.builder()
+            .id(1L)
+            .tickerCode("005930")
+            .companyName("삼성전자")
+            .ranking(1)
+            .modelBundleId("BUNDLE-TEST")
+            .modelGeneratedAt("2026-06-01T09:55:00+09:00")
+            .modelAsof("2026-06-01T09:54:00+09:00")
+            .build();
+    when(recommendationRepository
+            .findFirstByModelGeneratedAtIsNotNullOrderByModelGeneratedAtDescRankingAsc())
+        .thenReturn(Optional.of(stale));
+
+    assertThatThrownBy(service::findRecommendationList)
+        .isInstanceOf(GeneralException.class)
+        .extracting("code")
+        .isEqualTo(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
+
+    verify(recommendationRepository, never())
+        .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            "2026-06-01T09:55:00+09:00", "BUNDLE-TEST");
+    verifyNoInteractions(aiServerClient);
   }
 
   @Test

--- a/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImplTest.java
@@ -42,6 +42,7 @@ class RecommendationQueryServiceImplTest {
     ReflectionTestUtils.setField(service, "includeRecommendationDiagnostics", false);
     ReflectionTestUtils.setField(service, "cacheReadEnabled", false);
     ReflectionTestUtils.setField(service, "cacheMaxAgeSeconds", 180L);
+    ReflectionTestUtils.setField(service, "cacheMaxFutureSkewSeconds", 5L);
     ReflectionTestUtils.setField(
         service, "clock", Clock.fixed(Instant.parse("2026-06-01T01:01:00Z"), ZoneOffset.UTC));
   }
@@ -126,9 +127,7 @@ class RecommendationQueryServiceImplTest {
             .modelAsof("2026-06-01T09:59:00+09:00")
             .riskLevel("low")
             .build();
-    when(recommendationRepository
-            .findFirstByModelGeneratedAtIsNotNullOrderByModelGeneratedAtDescRankingAsc())
-        .thenReturn(Optional.of(cached));
+    when(recommendationRepository.findByModelGeneratedAtIsNotNull()).thenReturn(List.of(cached));
     when(recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
             "2026-06-01T10:00:00+09:00", "BUNDLE-TEST"))
         .thenReturn(List.of(cached));
@@ -180,9 +179,8 @@ class RecommendationQueryServiceImplTest {
             .modelGeneratedAt("2026-06-01T09:55:00+09:00")
             .modelAsof("2026-06-01T09:54:00+09:00")
             .build();
-    when(recommendationRepository
-            .findFirstByModelGeneratedAtIsNotNullOrderByModelGeneratedAtDescRankingAsc())
-        .thenReturn(Optional.of(latest));
+    when(recommendationRepository.findByModelGeneratedAtIsNotNull())
+        .thenReturn(List.of(old, latest));
     when(recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
             "2026-06-01T10:00:00+09:00", "BUNDLE-LATEST"))
         .thenReturn(List.of(latest));
@@ -199,6 +197,49 @@ class RecommendationQueryServiceImplTest {
   }
 
   @Test
+  void selectsLatestCachedBatchByParsedTimestampInsteadOfStringOrder() {
+    ReflectionTestUtils.setField(service, "cacheReadEnabled", true);
+    Recommendation stringSortedFirstButOlder =
+        Recommendation.builder()
+            .id(1L)
+            .tickerCode("005930")
+            .companyName("삼성전자")
+            .ranking(1)
+            .modelBundleId("BUNDLE-KST-OLDER")
+            .modelGeneratedAt("2026-06-01T10:30:00+09:00")
+            .modelAsof("2026-06-01T10:29:00+09:00")
+            .build();
+    Recommendation actuallyLatest =
+        Recommendation.builder()
+            .id(2L)
+            .tickerCode("000660")
+            .companyName("SK하이닉스")
+            .ranking(1)
+            .modelBundleId("BUNDLE-UTC-LATEST")
+            .modelGeneratedAt("2026-06-01T02:00:00Z")
+            .modelAsof("2026-06-01T01:59:00Z")
+            .build();
+    ReflectionTestUtils.setField(
+        service, "clock", Clock.fixed(Instant.parse("2026-06-01T02:01:00Z"), ZoneOffset.UTC));
+    when(recommendationRepository.findByModelGeneratedAtIsNotNull())
+        .thenReturn(List.of(stringSortedFirstButOlder, actuallyLatest));
+    when(recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            "2026-06-01T02:00:00Z", "BUNDLE-UTC-LATEST"))
+        .thenReturn(List.of(actuallyLatest));
+
+    RecommendationResDTO.RecommendationListDTO result = service.findRecommendationList();
+
+    assertThat(result.getBundleId()).isEqualTo("BUNDLE-UTC-LATEST");
+    assertThat(result.getGeneratedAt()).isEqualTo("2026-06-01T02:00:00Z");
+    verify(recommendationRepository)
+        .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            "2026-06-01T02:00:00Z", "BUNDLE-UTC-LATEST");
+    verify(recommendationRepository, never())
+        .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            "2026-06-01T10:30:00+09:00", "BUNDLE-KST-OLDER");
+  }
+
+  @Test
   void rejectsStaleCachedRecommendationsBeforeReturningRows() {
     ReflectionTestUtils.setField(service, "cacheReadEnabled", true);
     Recommendation stale =
@@ -211,9 +252,7 @@ class RecommendationQueryServiceImplTest {
             .modelGeneratedAt("2026-06-01T09:55:00+09:00")
             .modelAsof("2026-06-01T09:54:00+09:00")
             .build();
-    when(recommendationRepository
-            .findFirstByModelGeneratedAtIsNotNullOrderByModelGeneratedAtDescRankingAsc())
-        .thenReturn(Optional.of(stale));
+    when(recommendationRepository.findByModelGeneratedAtIsNotNull()).thenReturn(List.of(stale));
 
     assertThatThrownBy(service::findRecommendationList)
         .isInstanceOf(GeneralException.class)
@@ -223,6 +262,32 @@ class RecommendationQueryServiceImplTest {
     verify(recommendationRepository, never())
         .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
             "2026-06-01T09:55:00+09:00", "BUNDLE-TEST");
+    verifyNoInteractions(aiServerClient);
+  }
+
+  @Test
+  void rejectsFutureCachedRecommendationsBeyondClockSkew() {
+    ReflectionTestUtils.setField(service, "cacheReadEnabled", true);
+    Recommendation future =
+        Recommendation.builder()
+            .id(1L)
+            .tickerCode("005930")
+            .companyName("삼성전자")
+            .ranking(1)
+            .modelBundleId("BUNDLE-FUTURE")
+            .modelGeneratedAt("2026-06-01T01:02:00Z")
+            .modelAsof("2026-06-01T01:01:00Z")
+            .build();
+    when(recommendationRepository.findByModelGeneratedAtIsNotNull()).thenReturn(List.of(future));
+
+    assertThatThrownBy(service::findRecommendationList)
+        .isInstanceOf(GeneralException.class)
+        .extracting("code")
+        .isEqualTo(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
+
+    verify(recommendationRepository, never())
+        .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            "2026-06-01T01:02:00Z", "BUNDLE-FUTURE");
     verifyNoInteractions(aiServerClient);
   }
 

--- a/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImplTest.java
@@ -19,6 +19,7 @@ import com.example.elephantfinancelab_be.global.apiPayload.exception.GeneralExce
 import com.example.elephantfinancelab_be.global.config.AiServerClient;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
@@ -45,6 +46,10 @@ class RecommendationQueryServiceImplTest {
     ReflectionTestUtils.setField(service, "cacheMaxFutureSkewSeconds", 5L);
     ReflectionTestUtils.setField(
         service, "clock", Clock.fixed(Instant.parse("2026-06-01T01:01:00Z"), ZoneOffset.UTC));
+  }
+
+  private static OffsetDateTime generatedAt(String raw) {
+    return OffsetDateTime.parse(raw);
   }
 
   @Test
@@ -99,6 +104,7 @@ class RecommendationQueryServiceImplTest {
     RecommendationResDTO.RecommendationListDTO result = service.findRecommendationList();
 
     assertThat(result.getModelStatus()).isEqualTo("PASS");
+    assertThat(result.getGeneratedAt()).isEqualTo("2026-05-26T09:10:00+09:00");
     assertThat(result.getRecommendations())
         .extracting(RecommendationResDTO.RecommendationInfoDTO::getStockCode)
         .containsExactly("005930", "000660");
@@ -106,6 +112,7 @@ class RecommendationQueryServiceImplTest {
         .isEqualTo("MODEL-1");
     assertThat(result.getRecommendations().getFirst().getExpectedReturn()).isNull();
     assertThat(existing.getCompanyName()).isEqualTo("삼성전자");
+    assertThat(existing.getModelGeneratedAt()).isEqualTo(generatedAt("2026-05-26T09:10:00+09:00"));
     verify(aiServerClient).getRecommendations("BUNDLE-TEST", 10, false);
     verify(recommendationRepository).saveAll(org.mockito.ArgumentMatchers.anyList());
   }
@@ -123,13 +130,13 @@ class RecommendationQueryServiceImplTest {
             .modelRecommendationId("MODEL-1")
             .modelBundleId("BUNDLE-TEST")
             .modelVersion("v2")
-            .modelGeneratedAt("2026-06-01T10:00:00+09:00")
+            .modelGeneratedAt(generatedAt("2026-06-01T10:00:00+09:00"))
             .modelAsof("2026-06-01T09:59:00+09:00")
             .riskLevel("low")
             .build();
     when(recommendationRepository.findByModelGeneratedAtIsNotNull()).thenReturn(List.of(cached));
     when(recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
-            "2026-06-01T10:00:00+09:00", "BUNDLE-TEST"))
+            generatedAt("2026-06-01T10:00:00+09:00"), "BUNDLE-TEST"))
         .thenReturn(List.of(cached));
 
     RecommendationResDTO.RecommendationListDTO result = service.findRecommendationList();
@@ -147,7 +154,7 @@ class RecommendationQueryServiceImplTest {
         .containsExactly("005930");
     verify(recommendationRepository)
         .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
-            "2026-06-01T10:00:00+09:00", "BUNDLE-TEST");
+            generatedAt("2026-06-01T10:00:00+09:00"), "BUNDLE-TEST");
     verifyNoInteractions(aiServerClient);
   }
 
@@ -164,7 +171,7 @@ class RecommendationQueryServiceImplTest {
             .modelRecommendationId("MODEL-1")
             .modelBundleId("BUNDLE-LATEST")
             .modelVersion("v2")
-            .modelGeneratedAt("2026-06-01T10:00:00+09:00")
+            .modelGeneratedAt(generatedAt("2026-06-01T10:00:00+09:00"))
             .modelAsof("2026-06-01T09:59:00+09:00")
             .riskLevel("low")
             .build();
@@ -176,13 +183,13 @@ class RecommendationQueryServiceImplTest {
             .ranking(2)
             .score(0.81)
             .modelBundleId("BUNDLE-OLD")
-            .modelGeneratedAt("2026-06-01T09:55:00+09:00")
+            .modelGeneratedAt(generatedAt("2026-06-01T09:55:00+09:00"))
             .modelAsof("2026-06-01T09:54:00+09:00")
             .build();
     when(recommendationRepository.findByModelGeneratedAtIsNotNull())
         .thenReturn(List.of(old, latest));
     when(recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
-            "2026-06-01T10:00:00+09:00", "BUNDLE-LATEST"))
+            generatedAt("2026-06-01T10:00:00+09:00"), "BUNDLE-LATEST"))
         .thenReturn(List.of(latest));
 
     RecommendationResDTO.RecommendationListDTO result = service.findRecommendationList();
@@ -206,7 +213,7 @@ class RecommendationQueryServiceImplTest {
             .companyName("삼성전자")
             .ranking(1)
             .modelBundleId("BUNDLE-KST-OLDER")
-            .modelGeneratedAt("2026-06-01T10:30:00+09:00")
+            .modelGeneratedAt(generatedAt("2026-06-01T10:30:00+09:00"))
             .modelAsof("2026-06-01T10:29:00+09:00")
             .build();
     Recommendation actuallyLatest =
@@ -216,7 +223,7 @@ class RecommendationQueryServiceImplTest {
             .companyName("SK하이닉스")
             .ranking(1)
             .modelBundleId("BUNDLE-UTC-LATEST")
-            .modelGeneratedAt("2026-06-01T02:00:00Z")
+            .modelGeneratedAt(generatedAt("2026-06-01T02:00:00Z"))
             .modelAsof("2026-06-01T01:59:00Z")
             .build();
     ReflectionTestUtils.setField(
@@ -224,7 +231,7 @@ class RecommendationQueryServiceImplTest {
     when(recommendationRepository.findByModelGeneratedAtIsNotNull())
         .thenReturn(List.of(stringSortedFirstButOlder, actuallyLatest));
     when(recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
-            "2026-06-01T02:00:00Z", "BUNDLE-UTC-LATEST"))
+            generatedAt("2026-06-01T02:00:00Z"), "BUNDLE-UTC-LATEST"))
         .thenReturn(List.of(actuallyLatest));
 
     RecommendationResDTO.RecommendationListDTO result = service.findRecommendationList();
@@ -233,10 +240,40 @@ class RecommendationQueryServiceImplTest {
     assertThat(result.getGeneratedAt()).isEqualTo("2026-06-01T02:00:00Z");
     verify(recommendationRepository)
         .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
-            "2026-06-01T02:00:00Z", "BUNDLE-UTC-LATEST");
+            generatedAt("2026-06-01T02:00:00Z"), "BUNDLE-UTC-LATEST");
     verify(recommendationRepository, never())
         .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
-            "2026-06-01T10:30:00+09:00", "BUNDLE-KST-OLDER");
+            generatedAt("2026-06-01T10:30:00+09:00"), "BUNDLE-KST-OLDER");
+  }
+
+  @Test
+  void rejectsAiResponseWithInvalidGeneratedAtBeforeSaving() {
+    GetRecommendationsResponse response =
+        GetRecommendationsResponse.newBuilder()
+            .setStatus("PASS")
+            .setReason("recommendations_ready")
+            .setGeneratedAt("not-a-timestamp")
+            .setBundleId("BUNDLE-TEST")
+            .setModelVersion("v2")
+            .addRecommendations(
+                RecommendationItem.newBuilder()
+                    .setRecommendationId("MODEL-1")
+                    .setStockCode("005930")
+                    .setStockName("삼성전자")
+                    .setRanking(1)
+                    .setScore(0.92)
+                    .setReason("MODEL_RANKING_SIGNAL")
+                    .setRiskLevel("low")
+                    .build())
+            .build();
+    when(aiServerClient.getRecommendations("BUNDLE-TEST", 10, false)).thenReturn(response);
+
+    assertThatThrownBy(service::findRecommendationList)
+        .isInstanceOf(GeneralException.class)
+        .extracting("code")
+        .isEqualTo(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
+
+    verify(recommendationRepository, never()).saveAll(org.mockito.ArgumentMatchers.anyList());
   }
 
   @Test
@@ -249,7 +286,7 @@ class RecommendationQueryServiceImplTest {
             .companyName("삼성전자")
             .ranking(1)
             .modelBundleId("BUNDLE-TEST")
-            .modelGeneratedAt("2026-06-01T09:55:00+09:00")
+            .modelGeneratedAt(generatedAt("2026-06-01T09:55:00+09:00"))
             .modelAsof("2026-06-01T09:54:00+09:00")
             .build();
     when(recommendationRepository.findByModelGeneratedAtIsNotNull()).thenReturn(List.of(stale));
@@ -261,7 +298,7 @@ class RecommendationQueryServiceImplTest {
 
     verify(recommendationRepository, never())
         .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
-            "2026-06-01T09:55:00+09:00", "BUNDLE-TEST");
+            generatedAt("2026-06-01T09:55:00+09:00"), "BUNDLE-TEST");
     verifyNoInteractions(aiServerClient);
   }
 
@@ -275,7 +312,7 @@ class RecommendationQueryServiceImplTest {
             .companyName("삼성전자")
             .ranking(1)
             .modelBundleId("BUNDLE-FUTURE")
-            .modelGeneratedAt("2026-06-01T01:02:00Z")
+            .modelGeneratedAt(generatedAt("2026-06-01T01:02:00Z"))
             .modelAsof("2026-06-01T01:01:00Z")
             .build();
     when(recommendationRepository.findByModelGeneratedAtIsNotNull()).thenReturn(List.of(future));
@@ -287,7 +324,7 @@ class RecommendationQueryServiceImplTest {
 
     verify(recommendationRepository, never())
         .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
-            "2026-06-01T01:02:00Z", "BUNDLE-FUTURE");
+            generatedAt("2026-06-01T01:02:00Z"), "BUNDLE-FUTURE");
     verifyNoInteractions(aiServerClient);
   }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -59,6 +59,7 @@ ai:
     cache-read-enabled: false
     cache:
       max-age-seconds: 180
+      max-future-skew-seconds: 5
     refresh:
       enabled: false
       fixed-delay-ms: 60000

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -56,6 +56,17 @@ ai:
     bundle-id: BUNDLE-TEST
     top-k: 10
     include-diagnostics: false
+    cache-read-enabled: false
+    cache:
+      max-age-seconds: 180
+    refresh:
+      enabled: false
+      fixed-delay-ms: 60000
+      initial-delay-ms: 10000
+      market-hours-only: true
+      market-open: "09:00"
+      market-close: "15:30"
+      market-holidays: "2026-06-03,2026-07-17"
 
 auto-trading:
   kafka:


### PR DESCRIPTION
## 💡 Issue
- 관련 이슈 없음

## 🏷️ Type
- [ ] `feat`   : 새로운 기능 추가
- [x] `fix`    : 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`  : 코드 포맷팅, 세미콜론 누락 등 (비즈니스 로직 변경 없음)
- [ ] `docs`   : 문서 수정
- [x] `test`   : 테스트 코드 추가 및 수정
- [ ] `chore`  : 빌드 업무 수정, 패키지 매니저 설정 등
- [x] `setting`: 환경 설정 및 라이브러리 추가
- [ ] `deploy` : 배포 관련

## 📝 Summary
- GPT Pro 운영 검수에서 지적된 추천 캐시 stale/mixed-batch 위험과 자동매매 시작 전 readiness preflight 누락을 보완했습니다.
- GPT Pro 2차 검수에서 짚은 `modelGeneratedAt` 문자열 정렬/미래 timestamp clock-skew 리스크도 추가로 막았습니다.
- 추천 캐시는 계속 read-only advisory 데이터이며, 추천 응답 자체가 주문/실거래 가능 신호로 해석되지 않도록 메타데이터를 명시했습니다.
- 자동매매 세션 시작은 AI service readiness가 order action을 허용할 때만 진행되며, live 관련 플래그가 켜져 있으면 paper-auto 시작 전에 차단합니다.

## 🛠️ Changes
- [x] 추천 캐시 조회 시 최신 `modelGeneratedAt` + `modelBundleId` batch만 반환하도록 격리
- [x] 최신 batch 선택을 raw string 정렬이 아니라 `OffsetDateTime` 파싱 기준으로 수행
- [x] `ai.recommendations.cache.max-age-seconds` 기본값 180초 추가 및 stale/invalid cache fail-closed 처리
- [x] `ai.recommendations.cache.max-future-skew-seconds` 기본값 5초 추가 및 future `generatedAt` fail-closed 처리
- [x] 추천 목록 응답에 `cacheAgeSec`, `stale`, `advisoryOnly`, `safeToEnableOrderActions=false`, `liveTradingAllowed=false` 메타데이터 추가
- [x] `POST /api/auto-trading/sessions` 시작 전에 `getServiceReadiness(bundleId)` preflight 추가
- [x] readiness가 order action을 허용하지 않거나 live 관련 플래그가 켜져 있으면 `StartPaperAutoTrading` 호출 전 차단
- [x] 추천 캐시 mixed-batch/stale/string-order/future-skew 및 자동매매 readiness gate 테스트 추가

## 📸 Screenshots
- UI 변경 없음

## ✅ Checklist
- [x] 내 코드가 스타일 가이드(Spotless)를 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] develop 브랜치의 최신 사항을 pull 받았나요?
  - 현재 BE PR들은 `main` base를 사용 중이라 `origin/main@721ee70` 기준 clean branch에서 작업했습니다.
- [x] 테스트(빌드)가 성공적으로 통과했나요?
  - `./gradlew test --tests 'com.example.elephantfinancelab_be.domain.recommendation.*' --tests 'com.example.elephantfinancelab_be.domain.autotrading.service.command.AutoTradingCommandServiceImplTest'` → 26 tests, 0 failures/errors/skips
  - `./gradlew spotlessCheck` → PASS

## 🔒 운영 안전 메모
- 이 PR은 BE 추천 캐시와 paper-auto 시작 게이트 보강입니다.
- live trading을 켜지 않습니다.
- AI 쪽 `active_version=null`, `live_trading_allowed=false` 불변을 전제로 합니다.
- cached recommendations는 추천/선택 데이터일 뿐, order/live enable permission이 아닙니다.
- FE 실제 연결 전에는 별도 readiness REST envelope과 FE 버튼 게이팅이 추가로 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 자동매매 시작 시 AI 서비스 준비 상태를 검사해 준비되지 않으면 시작을 차단
  * 추천 데이터 캐시 읽기/갱신 도입 및 캐시 유효성(최대 연령·미래 스큐) 관리 추가
  * 시장 운영시간·휴일을 반영한 추천 자동 갱신 스케줄 추가
  * 추천 응답에 캐시 상태, 신선도(stale) 및 거래 허용 관련 플래그 추가
* **Bug Fixes / Improvements**
  * 추천 생성시각 포맷 일관성 개선(타임스탬프 포맷 적용)
* **Tests**
  * 준비 게이트·캐시·스케줄러 동작을 검증하는 단위/통합 테스트 다수 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->