### PR TITLE
fix(be): paper 서비스 출범 게이트 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ curl -X POST http://localhost:8080/api/auto-trading/sessions \
   -H "Authorization: Bearer <access-token>" \
   -H "Idempotency-Key: demo-paper-auto-001" \
   -H "Content-Type: application/json" \
-  -d '{"recommendationIds":[1,2],"purchaseOptionId":2,"cycles":3,"intervalSec":10}'
+  -d '{"recommendationIds":[1,2],"purchaseOptionId":2}'
 ```
 
 Repeat the same `Idempotency-Key` to receive the stored session without

--- a/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/dto/req/AutoTradingReqDTO.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/dto/req/AutoTradingReqDTO.java
@@ -22,12 +22,10 @@ public class AutoTradingReqDTO {
     @Max(4)
     private Integer purchaseOptionId;
 
-    @NotNull
-    @Min(1)
+    @Min(0)
     private Integer cycles;
 
-    @NotNull
-    @Min(60)
+    @Min(0)
     private Integer intervalSec;
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/dto/req/AutoTradingReqDTO.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/dto/req/AutoTradingReqDTO.java
@@ -27,7 +27,7 @@ public class AutoTradingReqDTO {
     private Integer cycles;
 
     @NotNull
-    @Min(1)
+    @Min(60)
     private Integer intervalSec;
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/scheduler/AutoTradingOperationScheduler.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/scheduler/AutoTradingOperationScheduler.java
@@ -46,6 +46,7 @@ public class AutoTradingOperationScheduler {
 
   private static final String ACTIVE_SLOT = "SHARED_KIS_VIRTUAL_ACCOUNT";
   private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+  private static final int MIN_PAPER_INTERVAL_SEC = 60;
 
   private final AutoTradingCommandService autoTradingCommandService;
   private final AutoTradingQueryService autoTradingQueryService;
@@ -445,7 +446,7 @@ public class AutoTradingOperationScheduler {
     if (cycles < 1) {
       return Optional.of("invalid_cycles");
     }
-    if (intervalSec < 1) {
+    if (intervalSec < MIN_PAPER_INTERVAL_SEC) {
       return Optional.of("invalid_interval_sec");
     }
     if (retryAttempts < 1) {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImpl.java
@@ -12,12 +12,15 @@ import com.example.elephantfinancelab_be.domain.autotrading.entity.AutoTradingSe
 import com.example.elephantfinancelab_be.domain.autotrading.exception.AutoTradingException;
 import com.example.elephantfinancelab_be.domain.autotrading.exception.code.AutoTradingErrorCode;
 import com.example.elephantfinancelab_be.domain.autotrading.repository.AutoTradingSessionRepository;
+import com.example.elephantfinancelab_be.domain.recommendation.entity.Recommendation;
 import com.example.elephantfinancelab_be.domain.recommendation.entity.UserSelectedRecommendation;
 import com.example.elephantfinancelab_be.domain.recommendation.repository.UserSelectedRecommendationRepository;
 import com.example.elephantfinancelab_be.global.apiPayload.code.AiServerErrorCode;
 import com.example.elephantfinancelab_be.global.apiPayload.exception.AiServerException;
 import com.example.elephantfinancelab_be.global.apiPayload.util.AiDetailSanitizer;
 import com.example.elephantfinancelab_be.global.config.AiServerClient;
+import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
@@ -36,6 +39,7 @@ import org.springframework.stereotype.Service;
 public class AutoTradingCommandServiceImpl implements AutoTradingCommandService {
 
   private static final String ACTIVE_SLOT = "SHARED_KIS_VIRTUAL_ACCOUNT";
+  private static final int MIN_PAPER_INTERVAL_SEC = 60;
 
   private final AutoTradingSessionRepository autoTradingSessionRepository;
   private final UserSelectedRecommendationRepository userSelectedRecommendationRepository;
@@ -47,6 +51,14 @@ public class AutoTradingCommandServiceImpl implements AutoTradingCommandService 
   @Value("${ai.paper-auto.confirm-phrase:PAPER_AUTO_OK}")
   private String confirmPhrase;
 
+  @Value("${ai.recommendations.cache.max-age-seconds:180}")
+  private long recommendationStartMaxAgeSeconds;
+
+  @Value("${ai.recommendations.cache.max-future-skew-seconds:5}")
+  private long recommendationMaxFutureSkewSeconds;
+
+  private Clock clock = Clock.systemUTC();
+
   @Override
   public AutoTradingResDTO.Session startSession(
       Long userId, String idempotencyKey, AutoTradingReqDTO.StartSession request) {
@@ -56,7 +68,7 @@ public class AutoTradingCommandServiceImpl implements AutoTradingCommandService 
     }
     validatePurchaseOption(request.getPurchaseOptionId());
     validateNonNegative(request.getCycles(), "cycles");
-    validateNonNegative(request.getIntervalSec(), "intervalSec");
+    validateMinIntervalSec(request.getIntervalSec());
     List<Long> recommendationIds = request.getRecommendationIds().stream().distinct().toList();
     String requestedBundleId = normalizeBundleId(request.getBundleId());
     String resolvedBundleId = resolveBundleId(requestedBundleId);
@@ -85,7 +97,7 @@ public class AutoTradingCommandServiceImpl implements AutoTradingCommandService 
     }
     validatePurchaseOption(purchaseOptionId);
     validateNonNegative(cycles, "cycles");
-    validateNonNegative(intervalSec, "intervalSec");
+    validateMinIntervalSec(intervalSec);
     String resolvedBundleId = resolveBundleId(null);
     return startResolvedSession(
         userId,
@@ -316,13 +328,18 @@ public class AutoTradingCommandServiceImpl implements AutoTradingCommandService 
     List<UserSelectedRecommendation> selected =
         userSelectedRecommendationRepository.findAllByUserIdAndRecommendation_IdIn(
             userId, recommendationIds);
+    Map<Long, Recommendation> recommendationById = new LinkedHashMap<>();
     Map<Long, String> tickerByRecommendationId = new LinkedHashMap<>();
     Map<Long, String> bundleByRecommendationId = new LinkedHashMap<>();
     for (UserSelectedRecommendation item : selected) {
-      tickerByRecommendationId.putIfAbsent(
-          item.getRecommendation().getId(), item.getRecommendation().getTickerCode());
+      Recommendation recommendation = item.getRecommendation();
+      if (recommendation == null || recommendation.getId() == null) {
+        continue;
+      }
+      recommendationById.putIfAbsent(recommendation.getId(), recommendation);
+      tickerByRecommendationId.putIfAbsent(recommendation.getId(), recommendation.getTickerCode());
       bundleByRecommendationId.putIfAbsent(
-          item.getRecommendation().getId(), item.getRecommendation().getModelBundleId());
+          recommendation.getId(), recommendation.getModelBundleId());
     }
     if (!tickerByRecommendationId.keySet().containsAll(recommendationIds)) {
       throw new AutoTradingException(AutoTradingErrorCode.INVALID_RECOMMENDATIONS);
@@ -340,11 +357,33 @@ public class AutoTradingCommandServiceImpl implements AutoTradingCommandService 
       throw new AutoTradingException(
           AutoTradingErrorCode.READINESS_GATE_BLOCKED, "recommendation_bundle_mismatch");
     }
+    recommendationIds.forEach(
+        id -> validateSelectedRecommendationFreshness(recommendationById.get(id)));
     return recommendationIds.stream()
         .map(tickerByRecommendationId::get)
         .map(String::trim)
         .distinct()
         .toList();
+  }
+
+  private void validateSelectedRecommendationFreshness(Recommendation recommendation) {
+    if (recommendation == null || recommendation.getModelGeneratedAt() == null) {
+      throw new AutoTradingException(
+          AutoTradingErrorCode.READINESS_GATE_BLOCKED, "recommendation_generated_at_missing");
+    }
+    OffsetDateTime generatedAt = recommendation.getModelGeneratedAt();
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    if (generatedAt
+        .toInstant()
+        .isAfter(now.plusSeconds(recommendationMaxFutureSkewSeconds).toInstant())) {
+      throw new AutoTradingException(
+          AutoTradingErrorCode.READINESS_GATE_BLOCKED, "recommendation_generated_at_invalid");
+    }
+    long ageSec = Math.max(0L, Duration.between(generatedAt, now).getSeconds());
+    if (ageSec > recommendationStartMaxAgeSeconds) {
+      throw new AutoTradingException(
+          AutoTradingErrorCode.READINESS_GATE_BLOCKED, "recommendation_cache_stale");
+    }
   }
 
   private void requirePaperAutoReadiness(String resolvedBundleId) {
@@ -424,6 +463,13 @@ public class AutoTradingCommandServiceImpl implements AutoTradingCommandService 
   private static void validateNonNegative(Integer value, String fieldName) {
     if (value != null && value < 0) {
       throw new IllegalArgumentException(fieldName + " must be non-negative");
+    }
+  }
+
+  private static void validateMinIntervalSec(Integer value) {
+    if (value != null && value < MIN_PAPER_INTERVAL_SEC) {
+      throw new IllegalArgumentException(
+          "intervalSec must be at least " + MIN_PAPER_INTERVAL_SEC + " seconds");
     }
   }
 

--- a/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImpl.java
@@ -467,7 +467,7 @@ public class AutoTradingCommandServiceImpl implements AutoTradingCommandService 
   }
 
   private static void validateMinIntervalSec(Integer value) {
-    if (value != null && value < MIN_PAPER_INTERVAL_SEC) {
+    if (value != null && value != 0 && value < MIN_PAPER_INTERVAL_SEC) {
       throw new IllegalArgumentException(
           "intervalSec must be at least " + MIN_PAPER_INTERVAL_SEC + " seconds");
     }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/MarketIndexRedisService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/MarketIndexRedisService.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -38,6 +39,12 @@ public class MarketIndexRedisService {
           index.value(),
           index.timestamp());
       return true;
+    } catch (DataAccessException e) {
+      log.warn(
+          "market index redis save skipped: key={}, reason=redis_unavailable",
+          market.getRedisKey(),
+          e);
+      return false;
     } catch (JsonProcessingException e) {
       throw new ChartException(ChartErrorCode.MARKET_INDEX_CACHE_SERIALIZE_FAILED, e);
     }
@@ -49,13 +56,12 @@ public class MarketIndexRedisService {
   }
 
   private MarketIndexResDTO.MarketIndex findLatest(MarketIndexMarket market) {
-    String json = stringRedisTemplate.opsForValue().get(market.getRedisKey());
-    if (json == null || json.isBlank()) {
-      log.info("market index redis miss: key={}", market.getRedisKey());
-      return null;
-    }
-
     try {
+      String json = stringRedisTemplate.opsForValue().get(market.getRedisKey());
+      if (json == null || json.isBlank()) {
+        log.info("market index redis miss: key={}", market.getRedisKey());
+        return null;
+      }
       MarketIndexResDTO.MarketIndex index =
           objectMapper.readValue(json, MarketIndexResDTO.MarketIndex.class);
       log.info(
@@ -64,12 +70,15 @@ public class MarketIndexRedisService {
           index.value(),
           index.timestamp());
       return index;
+    } catch (DataAccessException e) {
+      log.warn("market index redis unavailable: key={}", market.getRedisKey(), e);
+      return null;
     } catch (JsonProcessingException e) {
       log.warn(
           "market index redis deserialize failed: key={}, keep cache value unavailable",
           market.getRedisKey(),
           e);
-      throw new ChartException(ChartErrorCode.MARKET_INDEX_CACHE_DESERIALIZE_FAILED, e);
+      return null;
     }
   }
 

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/StockRankingService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/StockRankingService.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -49,13 +50,15 @@ public class StockRankingService {
   }
 
   private RankingResDTO.RankingResponse findCachedRanking(RankingType type) {
-    String json = stringRedisTemplate.opsForValue().get(type.getRedisKey());
-    if (json == null || json.isBlank()) {
-      return null;
-    }
-
     try {
+      String json = stringRedisTemplate.opsForValue().get(type.getRedisKey());
+      if (json == null || json.isBlank()) {
+        return null;
+      }
       return objectMapper.readValue(json, RankingResDTO.RankingResponse.class);
+    } catch (DataAccessException e) {
+      log.warn("ranking redis unavailable: key={}", type.getRedisKey(), e);
+      return null;
     } catch (JsonProcessingException e) {
       log.warn(
           "code={}, message={}, key={}",
@@ -72,8 +75,15 @@ public class StockRankingService {
       String json = objectMapper.writeValueAsString(response);
       stringRedisTemplate.opsForValue().set(type.getRedisKey(), json, CACHE_TTL);
       log.info("종목 랭킹 캐시 저장 완료. key={}, ttlSeconds={}", type.getRedisKey(), CACHE_TTL.toSeconds());
+    } catch (DataAccessException e) {
+      log.warn("ranking redis save skipped: key={}", type.getRedisKey(), e);
     } catch (JsonProcessingException e) {
-      throw new ChartException(ChartErrorCode.RANKING_CACHE_SERIALIZE_FAILED, e);
+      log.warn(
+          "code={}, message={}, key={}",
+          ChartErrorCode.RANKING_CACHE_SERIALIZE_FAILED.getCode(),
+          ChartErrorCode.RANKING_CACHE_SERIALIZE_FAILED.getMessage(),
+          type.getRedisKey(),
+          e);
     }
   }
 }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/converter/RecommendationConverter.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/converter/RecommendationConverter.java
@@ -104,6 +104,11 @@ public final class RecommendationConverter {
 
   public static RecommendationResDTO.RecommendationDetailDTO toRecommendationDetailDTO(
       Recommendation entity, String profile) {
+    return toRecommendationDetailDTO(entity, profile, null, false, null);
+  }
+
+  public static RecommendationResDTO.RecommendationDetailDTO toRecommendationDetailDTO(
+      Recommendation entity, String profile, Long cacheAgeSec, Boolean stale, String staleReason) {
     return RecommendationResDTO.RecommendationDetailDTO.builder()
         .recommendationId(entity.getId())
         .modelRecommendationId(entity.getModelRecommendationId())
@@ -130,6 +135,12 @@ public final class RecommendationConverter {
         .bundleId(entity.getModelBundleId())
         .modelGeneratedAt(formatGeneratedAt(entity.getModelGeneratedAt()))
         .modelAsof(entity.getModelAsof())
+        .cacheAgeSec(cacheAgeSec)
+        .stale(stale)
+        .staleReason(staleReason)
+        .advisoryOnly(true)
+        .safeToEnableOrderActions(false)
+        .liveTradingAllowed(false)
         .sections(
             RecommendationResDTO.DetailSectionsDTO.builder()
                 .recommendReason(entity.getRecommendReason())

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/dto/res/RecommendationResDTO.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/dto/res/RecommendationResDTO.java
@@ -92,6 +92,12 @@ public class RecommendationResDTO {
     private String bundleId;
     private String modelGeneratedAt;
     private String modelAsof;
+    private Long cacheAgeSec;
+    private Boolean stale;
+    private String staleReason;
+    private Boolean advisoryOnly;
+    private Boolean safeToEnableOrderActions;
+    private Boolean liveTradingAllowed;
   }
 
   @Builder

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImpl.java
@@ -124,15 +124,7 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
     OffsetDateTime latestGeneratedAt = latest.getModelGeneratedAt();
     long cacheAgeSec = cacheAgeSec(latestGeneratedAt);
     boolean stale = cacheAgeSec > cacheMaxAgeSeconds;
-    if (stale && (!allowStaleDisplay || cacheAgeSec > cacheDisplayMaxAgeSeconds)) {
-      log.warn(
-          "[Recommendation] cached model recommendations too stale for display: generatedAt={}, ageSec={}, freshMaxAgeSec={}, displayMaxAgeSec={}",
-          formatGeneratedAt(latestGeneratedAt),
-          cacheAgeSec,
-          cacheMaxAgeSeconds,
-          cacheDisplayMaxAgeSeconds);
-      throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
-    }
+    rejectIfTooStaleForDisplay(latestGeneratedAt, cacheAgeSec, stale);
     List<Recommendation> savedRecommendations =
         recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
             latestGeneratedAt, latest.getModelBundleId());
@@ -274,7 +266,22 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
     }
     long cacheAgeSec = Math.max(0L, Duration.between(generated, now).getSeconds());
     boolean stale = cacheAgeSec > cacheMaxAgeSeconds;
+    rejectIfTooStaleForDisplay(generated, cacheAgeSec, stale);
     return new DetailCacheState(cacheAgeSec, stale, stale ? "cache_stale" : null);
+  }
+
+  private void rejectIfTooStaleForDisplay(
+      OffsetDateTime generatedAt, long cacheAgeSec, boolean stale) {
+    if (!stale || (allowStaleDisplay && cacheAgeSec <= cacheDisplayMaxAgeSeconds)) {
+      return;
+    }
+    log.warn(
+        "[Recommendation] cached model recommendations too stale for display: generatedAt={}, ageSec={}, freshMaxAgeSec={}, displayMaxAgeSec={}",
+        formatGeneratedAt(generatedAt),
+        cacheAgeSec,
+        cacheMaxAgeSeconds,
+        cacheDisplayMaxAgeSeconds);
+    throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
   }
 
   private Recommendation findLatestCachedRecommendation() {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImpl.java
@@ -63,6 +63,12 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
   @Value("${ai.recommendations.cache.max-age-seconds:180}")
   private long cacheMaxAgeSeconds;
 
+  @Value("${ai.recommendations.cache.display-max-age-seconds:86400}")
+  private long cacheDisplayMaxAgeSeconds;
+
+  @Value("${ai.recommendations.cache.allow-stale-display:true}")
+  private boolean allowStaleDisplay;
+
   @Value("${ai.recommendations.cache.max-future-skew-seconds:5}")
   private long cacheMaxFutureSkewSeconds;
 
@@ -117,12 +123,14 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
     Recommendation latest = findLatestCachedRecommendation();
     OffsetDateTime latestGeneratedAt = latest.getModelGeneratedAt();
     long cacheAgeSec = cacheAgeSec(latestGeneratedAt);
-    if (cacheAgeSec > cacheMaxAgeSeconds) {
+    boolean stale = cacheAgeSec > cacheMaxAgeSeconds;
+    if (stale && (!allowStaleDisplay || cacheAgeSec > cacheDisplayMaxAgeSeconds)) {
       log.warn(
-          "[Recommendation] cached model recommendations stale: generatedAt={}, ageSec={}, maxAgeSec={}",
+          "[Recommendation] cached model recommendations too stale for display: generatedAt={}, ageSec={}, freshMaxAgeSec={}, displayMaxAgeSec={}",
           formatGeneratedAt(latestGeneratedAt),
           cacheAgeSec,
-          cacheMaxAgeSeconds);
+          cacheMaxAgeSeconds,
+          cacheDisplayMaxAgeSeconds);
       throw new GeneralException(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
     }
     List<Recommendation> savedRecommendations =
@@ -146,8 +154,8 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
         latest.getModelAsof(),
         "cached",
         cacheAgeSec,
-        false,
-        null,
+        stale,
+        stale ? "cache_stale" : null,
         infoList);
   }
 
@@ -159,7 +167,13 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
             .findById(recommendationId)
             .orElseThrow(
                 () -> new GeneralException(RecommendationErrorCode.RECOMMENDATION_NOT_FOUND));
-    return RecommendationConverter.toRecommendationDetailDTO(recommendation, "맞춤형 투자 전략 분석");
+    DetailCacheState cacheState = detailCacheState(recommendation.getModelGeneratedAt());
+    return RecommendationConverter.toRecommendationDetailDTO(
+        recommendation,
+        "맞춤형 투자 전략 분석",
+        cacheState.cacheAgeSec(),
+        cacheState.stale(),
+        cacheState.staleReason());
   }
 
   @Override
@@ -169,7 +183,13 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
             .findByTickerCodeIgnoreCase(stockCode.trim())
             .orElseThrow(
                 () -> new GeneralException(RecommendationErrorCode.RECOMMENDATION_NOT_FOUND));
-    return RecommendationConverter.toRecommendationDetailDTO(recommendation, "맞춤형 투자 전략 분석");
+    DetailCacheState cacheState = detailCacheState(recommendation.getModelGeneratedAt());
+    return RecommendationConverter.toRecommendationDetailDTO(
+        recommendation,
+        "맞춤형 투자 전략 분석",
+        cacheState.cacheAgeSec(),
+        cacheState.stale(),
+        cacheState.staleReason());
   }
 
   @Override
@@ -244,6 +264,19 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
     return Math.max(0L, ageSec);
   }
 
+  private DetailCacheState detailCacheState(OffsetDateTime generated) {
+    if (generated == null) {
+      return new DetailCacheState(null, true, "recommendation_generated_at_missing");
+    }
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    if (generated.toInstant().isAfter(now.plusSeconds(cacheMaxFutureSkewSeconds).toInstant())) {
+      return new DetailCacheState(null, true, "recommendation_generated_at_invalid");
+    }
+    long cacheAgeSec = Math.max(0L, Duration.between(generated, now).getSeconds());
+    boolean stale = cacheAgeSec > cacheMaxAgeSeconds;
+    return new DetailCacheState(cacheAgeSec, stale, stale ? "cache_stale" : null);
+  }
+
   private Recommendation findLatestCachedRecommendation() {
     return recommendationRepository.findByModelGeneratedAtIsNotNull().stream()
         .sorted(
@@ -270,4 +303,6 @@ public class RecommendationQueryServiceImpl implements RecommendationQueryServic
   private String formatGeneratedAt(OffsetDateTime generatedAt) {
     return generatedAt == null ? null : MODEL_GENERATED_AT_FORMATTER.format(generatedAt);
   }
+
+  private record DetailCacheState(Long cacheAgeSec, boolean stale, String staleReason) {}
 }

--- a/src/main/java/com/example/elephantfinancelab_be/global/config/AiServerClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/global/config/AiServerClient.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -37,16 +38,43 @@ public class AiServerClient {
 
   private final AiBeBridgeServiceGrpc.AiBeBridgeServiceBlockingStub stub;
   private final int timeout;
+  private final int healthTimeout;
+  private final int readinessTimeout;
+  private final int recommendationsTimeout;
+  private final int paperStartTimeout;
+  private final int paperStatusTimeout;
+  private final int paperStopTimeout;
 
+  @Autowired
   public AiServerClient(
       AiBeBridgeServiceGrpc.AiBeBridgeServiceBlockingStub stub,
-      @Value("${ai.server.timeout}") int timeout) {
+      @Value("${ai.server.timeout}") int timeout,
+      @Value("${ai.server.timeout-health:3}") int healthTimeout,
+      @Value("${ai.server.timeout-readiness:10}") int readinessTimeout,
+      @Value("${ai.server.timeout-recommendations:90}") int recommendationsTimeout,
+      @Value("${ai.server.timeout-paper-start:30}") int paperStartTimeout,
+      @Value("${ai.server.timeout-paper-status:5}") int paperStatusTimeout,
+      @Value("${ai.server.timeout-paper-stop:10}") int paperStopTimeout) {
     this.stub = stub;
     this.timeout = timeout;
+    this.healthTimeout = healthTimeout;
+    this.readinessTimeout = readinessTimeout;
+    this.recommendationsTimeout = recommendationsTimeout;
+    this.paperStartTimeout = paperStartTimeout;
+    this.paperStatusTimeout = paperStatusTimeout;
+    this.paperStopTimeout = paperStopTimeout;
+  }
+
+  AiServerClient(AiBeBridgeServiceGrpc.AiBeBridgeServiceBlockingStub stub, int timeout) {
+    this(stub, timeout, timeout, timeout, timeout, timeout, timeout, timeout);
   }
 
   private AiBeBridgeServiceGrpc.AiBeBridgeServiceBlockingStub stubWithDeadline() {
-    return stub.withDeadlineAfter(timeout, TimeUnit.SECONDS);
+    return stubWithDeadline(timeout);
+  }
+
+  private AiBeBridgeServiceGrpc.AiBeBridgeServiceBlockingStub stubWithDeadline(int seconds) {
+    return stub.withDeadlineAfter(Math.max(1, seconds), TimeUnit.SECONDS);
   }
 
   AiServerException mapToAiServerException(StatusRuntimeException e) {
@@ -91,7 +119,7 @@ public class AiServerClient {
               .setRequestId(UUID.randomUUID().toString())
               .setBundleId(bundleId != null ? bundleId : "")
               .build();
-      HealthCheckResponse response = stubWithDeadline().healthCheck(request);
+      HealthCheckResponse response = stubWithDeadline(healthTimeout).healthCheck(request);
       log.info("[AI Client] 헬스체크: {}", response.getStatus());
       return response;
     } catch (StatusRuntimeException e) {
@@ -107,7 +135,7 @@ public class AiServerClient {
               .setBundleId(bundleId != null ? bundleId : "")
               .setIncludeDetails(true)
               .build();
-      return stubWithDeadline().getServiceReadiness(request);
+      return stubWithDeadline(readinessTimeout).getServiceReadiness(request);
     } catch (StatusRuntimeException e) {
       throw mapToAiServerException(e);
     }
@@ -174,7 +202,8 @@ public class AiServerClient {
       if (topK != null) {
         request.setTopK(topK);
       }
-      GetRecommendationsResponse response = stubWithDeadline().getRecommendations(request.build());
+      GetRecommendationsResponse response =
+          stubWithDeadline(recommendationsTimeout).getRecommendations(request.build());
       log.info(
           "[AI Client] 추천 조회 완료: status={}, count={}",
           response.getStatus(),
@@ -205,7 +234,7 @@ public class AiServerClient {
       if (intervalSec != null) {
         builder.setIntervalSec(intervalSec);
       }
-      return stubWithDeadline().startPaperAutoTrading(builder.build());
+      return stubWithDeadline(paperStartTimeout).startPaperAutoTrading(builder.build());
     } catch (StatusRuntimeException e) {
       throw mapToAiServerException(e);
     }
@@ -218,7 +247,7 @@ public class AiServerClient {
               .setRequestId(requestId)
               .setSessionId(aiSessionId != null ? aiSessionId : "")
               .build();
-      return stubWithDeadline().stopPaperAutoTrading(request);
+      return stubWithDeadline(paperStopTimeout).stopPaperAutoTrading(request);
     } catch (StatusRuntimeException e) {
       throw mapToAiServerException(e);
     }
@@ -228,7 +257,7 @@ public class AiServerClient {
     try {
       GetPaperAutoTradingStatusRequest request =
           GetPaperAutoTradingStatusRequest.newBuilder().setRequestId(requestId).build();
-      return stubWithDeadline().getPaperAutoTradingStatus(request);
+      return stubWithDeadline(paperStatusTimeout).getPaperAutoTradingStatus(request);
     } catch (StatusRuntimeException e) {
       throw mapToAiServerException(e);
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -80,6 +80,12 @@ ai:
     host: ${AI_SERVER_HOST:localhost}
     port: ${AI_SERVER_PORT:50051}
     timeout: ${AI_SERVER_TIMEOUT:5}
+    timeout-health: ${AI_SERVER_TIMEOUT_HEALTH:3}
+    timeout-readiness: ${AI_SERVER_TIMEOUT_READINESS:10}
+    timeout-recommendations: ${AI_SERVER_TIMEOUT_RECOMMENDATIONS:90}
+    timeout-paper-start: ${AI_SERVER_TIMEOUT_PAPER_START:30}
+    timeout-paper-status: ${AI_SERVER_TIMEOUT_PAPER_STATUS:5}
+    timeout-paper-stop: ${AI_SERVER_TIMEOUT_PAPER_STOP:10}
   paper-auto:
     bundle-id: ${AI_PAPER_BUNDLE_ID:}
     confirm-phrase: ${AI_PAPER_CONFIRM_PHRASE:PAPER_AUTO_OK}
@@ -87,9 +93,11 @@ ai:
     bundle-id: ${AI_RECOMMENDATION_BUNDLE_ID:}
     top-k: ${AI_RECOMMENDATION_TOP_K:10}
     include-diagnostics: ${AI_RECOMMENDATION_INCLUDE_DIAGNOSTICS:false}
-    cache-read-enabled: ${AI_RECOMMENDATION_CACHE_READ_ENABLED:false}
+    cache-read-enabled: ${AI_RECOMMENDATION_CACHE_READ_ENABLED:true}
     cache:
       max-age-seconds: ${AI_RECOMMENDATION_CACHE_MAX_AGE_SECONDS:180}
+      display-max-age-seconds: ${AI_RECOMMENDATION_CACHE_DISPLAY_MAX_AGE_SECONDS:86400}
+      allow-stale-display: ${AI_RECOMMENDATION_CACHE_ALLOW_STALE_DISPLAY:true}
       max-future-skew-seconds: ${AI_RECOMMENDATION_CACHE_MAX_FUTURE_SKEW_SECONDS:5}
     refresh:
       enabled: ${AI_RECOMMENDATION_REFRESH_ENABLED:false}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
     properties:
       hibernate:
         format_sql: true
@@ -119,6 +119,12 @@ ai:
     host: ${AI_SERVER_HOST:localhost}
     port: ${AI_SERVER_PORT:50051}
     timeout: ${AI_SERVER_TIMEOUT:5}
+    timeout-health: ${AI_SERVER_TIMEOUT_HEALTH:3}
+    timeout-readiness: ${AI_SERVER_TIMEOUT_READINESS:10}
+    timeout-recommendations: ${AI_SERVER_TIMEOUT_RECOMMENDATIONS:90}
+    timeout-paper-start: ${AI_SERVER_TIMEOUT_PAPER_START:30}
+    timeout-paper-status: ${AI_SERVER_TIMEOUT_PAPER_STATUS:5}
+    timeout-paper-stop: ${AI_SERVER_TIMEOUT_PAPER_STOP:10}
   paper-auto:
     bundle-id: ${AI_PAPER_BUNDLE_ID:}
     confirm-phrase: ${AI_PAPER_CONFIRM_PHRASE:PAPER_AUTO_OK}
@@ -126,9 +132,11 @@ ai:
     bundle-id: ${AI_RECOMMENDATION_BUNDLE_ID:}
     top-k: ${AI_RECOMMENDATION_TOP_K:10}
     include-diagnostics: ${AI_RECOMMENDATION_INCLUDE_DIAGNOSTICS:false}
-    cache-read-enabled: ${AI_RECOMMENDATION_CACHE_READ_ENABLED:false}
+    cache-read-enabled: ${AI_RECOMMENDATION_CACHE_READ_ENABLED:true}
     cache:
       max-age-seconds: ${AI_RECOMMENDATION_CACHE_MAX_AGE_SECONDS:180}
+      display-max-age-seconds: ${AI_RECOMMENDATION_CACHE_DISPLAY_MAX_AGE_SECONDS:86400}
+      allow-stale-display: ${AI_RECOMMENDATION_CACHE_ALLOW_STALE_DISPLAY:true}
       max-future-skew-seconds: ${AI_RECOMMENDATION_CACHE_MAX_FUTURE_SKEW_SECONDS:5}
     refresh:
       enabled: ${AI_RECOMMENDATION_REFRESH_ENABLED:false}

--- a/src/test/java/com/example/elephantfinancelab_be/domain/autotrading/dto/req/AutoTradingReqDTOTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/autotrading/dto/req/AutoTradingReqDTOTest.java
@@ -1,0 +1,35 @@
+package com.example.elephantfinancelab_be.domain.autotrading.dto.req;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class AutoTradingReqDTOTest {
+
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  void startSessionAllowsNullAndZeroAiDefaultFields() {
+    assertThat(validator.validate(request(null, null))).isEmpty();
+    assertThat(validator.validate(request(0, 0))).isEmpty();
+  }
+
+  @Test
+  void startSessionRejectsNegativeAiDefaultFields() {
+    assertThat(validator.validate(request(-1, -1)))
+        .extracting(violation -> violation.getPropertyPath().toString())
+        .contains("cycles", "intervalSec");
+  }
+
+  private static AutoTradingReqDTO.StartSession request(Integer cycles, Integer intervalSec) {
+    AutoTradingReqDTO.StartSession request = new AutoTradingReqDTO.StartSession();
+    ReflectionTestUtils.setField(request, "recommendationIds", java.util.List.of(1L));
+    ReflectionTestUtils.setField(request, "purchaseOptionId", 2);
+    ReflectionTestUtils.setField(request, "cycles", cycles);
+    ReflectionTestUtils.setField(request, "intervalSec", intervalSec);
+    return request;
+  }
+}

--- a/src/test/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImplTest.java
@@ -28,6 +28,10 @@ import com.example.elephantfinancelab_be.domain.recommendation.repository.UserSe
 import com.example.elephantfinancelab_be.global.apiPayload.code.AiServerErrorCode;
 import com.example.elephantfinancelab_be.global.apiPayload.exception.AiServerException;
 import com.example.elephantfinancelab_be.global.config.AiServerClient;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +53,10 @@ class AutoTradingCommandServiceImplTest {
   void setUp() {
     ReflectionTestUtils.setField(service, "bundleId", "BUNDLE-TEST");
     ReflectionTestUtils.setField(service, "confirmPhrase", "PAPER_AUTO_OK");
+    ReflectionTestUtils.setField(service, "recommendationStartMaxAgeSeconds", 180L);
+    ReflectionTestUtils.setField(service, "recommendationMaxFutureSkewSeconds", 5L);
+    ReflectionTestUtils.setField(
+        service, "clock", Clock.fixed(Instant.parse("2026-06-01T01:01:00Z"), ZoneOffset.UTC));
     when(sessionRepository.saveAndFlush(any(AutoTradingSession.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
   }
@@ -78,6 +86,18 @@ class AutoTradingCommandServiceImplTest {
     assertThat(result.getSelectedTickers()).containsExactly("005930");
     verify(aiServerClient)
         .startPaperAutoTrading(anyString(), anyString(), any(), any(), any(), anyString());
+  }
+
+  @Test
+  void rejectsSubMinutePaperAutoIntervalBeforeAiCall() {
+    AutoTradingReqDTO.StartSession request = request();
+    ReflectionTestUtils.setField(request, "intervalSec", 10);
+
+    assertThatThrownBy(() -> service.startSession(1L, "idempotency-short-interval", request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("intervalSec must be at least 60");
+
+    verifyNoInteractions(selectedRepository, aiServerClient);
   }
 
   @Test
@@ -561,6 +581,52 @@ class AutoTradingCommandServiceImplTest {
   }
 
   @Test
+  void rejectsStartWhenSelectedRecommendationGeneratedAtIsMissing() {
+    when(sessionRepository.findByUserIdAndIdempotencyKey(1L, "idempotency-1"))
+        .thenReturn(Optional.empty());
+    when(selectedRepository.findAllByUserIdAndRecommendation_IdIn(1L, List.of(1L)))
+        .thenReturn(
+            List.of(selectedRecommendationWithGeneratedAt(1L, "005930", "BUNDLE-TEST", null)));
+
+    assertThatThrownBy(() -> service.startSession(1L, "idempotency-1", request()))
+        .isInstanceOf(AutoTradingException.class)
+        .satisfies(
+            exception -> {
+              assertThat(exception).hasMessageContaining("recommendation_generated_at_missing");
+              assertThat(((AutoTradingException) exception).getCode())
+                  .isEqualTo(AutoTradingErrorCode.READINESS_GATE_BLOCKED);
+            });
+
+    verify(aiServerClient, never()).getServiceReadiness(anyString());
+    verify(aiServerClient, never())
+        .startPaperAutoTrading(anyString(), anyString(), any(), any(), any(), anyString());
+  }
+
+  @Test
+  void rejectsStartWhenSelectedRecommendationIsStale() {
+    when(sessionRepository.findByUserIdAndIdempotencyKey(1L, "idempotency-1"))
+        .thenReturn(Optional.empty());
+    when(selectedRepository.findAllByUserIdAndRecommendation_IdIn(1L, List.of(1L)))
+        .thenReturn(
+            List.of(
+                selectedRecommendationWithGeneratedAt(
+                    1L, "005930", "BUNDLE-TEST", "2026-06-01T09:55:00+09:00")));
+
+    assertThatThrownBy(() -> service.startSession(1L, "idempotency-1", request()))
+        .isInstanceOf(AutoTradingException.class)
+        .satisfies(
+            exception -> {
+              assertThat(exception).hasMessageContaining("recommendation_cache_stale");
+              assertThat(((AutoTradingException) exception).getCode())
+                  .isEqualTo(AutoTradingErrorCode.READINESS_GATE_BLOCKED);
+            });
+
+    verify(aiServerClient, never()).getServiceReadiness(anyString());
+    verify(aiServerClient, never())
+        .startPaperAutoTrading(anyString(), anyString(), any(), any(), any(), anyString());
+  }
+
+  @Test
   void treatsAiNotRunningStopResponseAsAlreadyStopped() {
     AutoTradingSession session =
         AutoTradingSession.builder()
@@ -595,7 +661,7 @@ class AutoTradingCommandServiceImplTest {
     ReflectionTestUtils.setField(request, "recommendationIds", recommendationIds);
     ReflectionTestUtils.setField(request, "purchaseOptionId", 2);
     ReflectionTestUtils.setField(request, "cycles", 3);
-    ReflectionTestUtils.setField(request, "intervalSec", 10);
+    ReflectionTestUtils.setField(request, "intervalSec", 60);
     return request;
   }
 
@@ -611,8 +677,18 @@ class AutoTradingCommandServiceImplTest {
 
   private static UserSelectedRecommendation selectedRecommendation(
       Long id, String ticker, String bundleId) {
+    return selectedRecommendationWithGeneratedAt(id, ticker, bundleId, "2026-06-01T10:00:00+09:00");
+  }
+
+  private static UserSelectedRecommendation selectedRecommendationWithGeneratedAt(
+      Long id, String ticker, String bundleId, String generatedAt) {
     Recommendation recommendation =
-        Recommendation.builder().id(id).tickerCode(ticker).modelBundleId(bundleId).build();
+        Recommendation.builder()
+            .id(id)
+            .tickerCode(ticker)
+            .modelBundleId(bundleId)
+            .modelGeneratedAt(generatedAt == null ? null : OffsetDateTime.parse(generatedAt))
+            .build();
     return UserSelectedRecommendation.builder().userId(1L).recommendation(recommendation).build();
   }
 

--- a/src/test/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/autotrading/service/command/AutoTradingCommandServiceImplTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -98,6 +100,63 @@ class AutoTradingCommandServiceImplTest {
         .hasMessageContaining("intervalSec must be at least 60");
 
     verifyNoInteractions(selectedRepository, aiServerClient);
+  }
+
+  @Test
+  void startsPaperAutoSessionWithNullCyclesAndIntervalForAiDefaults() {
+    when(sessionRepository.findByUserIdAndIdempotencyKey(1L, "idempotency-ai-default-null"))
+        .thenReturn(Optional.empty());
+    when(sessionRepository.existsByActiveSlot(anyString())).thenReturn(false);
+    when(selectedRepository.findAllByUserIdAndRecommendation_IdIn(1L, List.of(1L)))
+        .thenReturn(List.of(selectedRecommendation(1L, "005930", "BUNDLE-TEST")));
+    when(aiServerClient.getServiceReadiness("BUNDLE-TEST")).thenReturn(paperReady());
+    when(aiServerClient.startPaperAutoTrading(
+            anyString(), anyString(), any(), any(), any(), anyString()))
+        .thenReturn(
+            StartPaperAutoTradingResponse.newBuilder()
+                .setAccepted(true)
+                .setStatus("STARTED")
+                .setSessionId("ai-session-default-null")
+                .build());
+    AutoTradingReqDTO.StartSession request = request();
+    ReflectionTestUtils.setField(request, "cycles", null);
+    ReflectionTestUtils.setField(request, "intervalSec", null);
+
+    AutoTradingResDTO.Session result =
+        service.startSession(1L, "idempotency-ai-default-null", request);
+
+    assertThat(result.getStatus()).isEqualTo(AutoTradingSessionStatus.RUNNING);
+    verify(aiServerClient)
+        .startPaperAutoTrading(
+            anyString(), anyString(), isNull(), isNull(), any(), eq("PAPER_AUTO_OK"));
+  }
+
+  @Test
+  void startsPaperAutoSessionWithZeroCyclesAndIntervalForAiDefaults() {
+    when(sessionRepository.findByUserIdAndIdempotencyKey(1L, "idempotency-ai-default-zero"))
+        .thenReturn(Optional.empty());
+    when(sessionRepository.existsByActiveSlot(anyString())).thenReturn(false);
+    when(selectedRepository.findAllByUserIdAndRecommendation_IdIn(1L, List.of(1L)))
+        .thenReturn(List.of(selectedRecommendation(1L, "005930", "BUNDLE-TEST")));
+    when(aiServerClient.getServiceReadiness("BUNDLE-TEST")).thenReturn(paperReady());
+    when(aiServerClient.startPaperAutoTrading(
+            anyString(), anyString(), any(), any(), any(), anyString()))
+        .thenReturn(
+            StartPaperAutoTradingResponse.newBuilder()
+                .setAccepted(true)
+                .setStatus("STARTED")
+                .setSessionId("ai-session-default-zero")
+                .build());
+    AutoTradingReqDTO.StartSession request = request();
+    ReflectionTestUtils.setField(request, "cycles", 0);
+    ReflectionTestUtils.setField(request, "intervalSec", 0);
+
+    AutoTradingResDTO.Session result =
+        service.startSession(1L, "idempotency-ai-default-zero", request);
+
+    assertThat(result.getStatus()).isEqualTo(AutoTradingSessionStatus.RUNNING);
+    verify(aiServerClient)
+        .startPaperAutoTrading(anyString(), anyString(), eq(0), eq(0), any(), eq("PAPER_AUTO_OK"));
   }
 
   @Test

--- a/src/test/java/com/example/elephantfinancelab_be/domain/chart/service/MarketIndexRedisServiceTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/chart/service/MarketIndexRedisServiceTest.java
@@ -3,6 +3,7 @@ package com.example.elephantfinancelab_be.domain.chart.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
@@ -111,5 +113,36 @@ class MarketIndexRedisServiceTest {
 
     assertThat(result.kospi()).isEqualTo(kospi);
     assertThat(result.kosdaq()).isNull();
+  }
+
+  @Test
+  void findLatestMarketIndexesReturnsNullWhenRedisUnavailable() {
+    when(valueOperations.get(MarketIndexMarket.KOSPI.getRedisKey()))
+        .thenThrow(new RedisConnectionFailureException("redis down"));
+    when(valueOperations.get(MarketIndexMarket.KOSDAQ.getRedisKey()))
+        .thenThrow(new RedisConnectionFailureException("redis down"));
+
+    MarketIndexResDTO.MarketIndexes result = service.findLatestMarketIndexes();
+
+    assertThat(result.kospi()).isNull();
+    assertThat(result.kosdaq()).isNull();
+  }
+
+  @Test
+  void saveReturnsFalseWhenRedisUnavailable() {
+    MarketIndexResDTO.MarketIndex index =
+        new MarketIndexResDTO.MarketIndex(
+            "KOSPI",
+            new BigDecimal("2735.24"),
+            new BigDecimal("12.31"),
+            new BigDecimal("0.45"),
+            TIMESTAMP);
+    doThrow(new RedisConnectionFailureException("redis down"))
+        .when(valueOperations)
+        .set(eq(MarketIndexMarket.KOSPI.getRedisKey()), anyString());
+
+    boolean saved = service.save(MarketIndexMarket.KOSPI, index);
+
+    assertThat(saved).isFalse();
   }
 }

--- a/src/test/java/com/example/elephantfinancelab_be/domain/chart/service/StockRankingServiceTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/chart/service/StockRankingServiceTest.java
@@ -1,0 +1,78 @@
+package com.example.elephantfinancelab_be.domain.chart.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.elephantfinancelab_be.domain.chart.dto.res.RankingResDTO;
+import com.example.elephantfinancelab_be.domain.chart.entity.RankingType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class StockRankingServiceTest {
+
+  private final StringRedisTemplate stringRedisTemplate = mock(StringRedisTemplate.class);
+
+  @SuppressWarnings("unchecked")
+  private final ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+
+  private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+  private final KisStockRankingClient kisStockRankingClient = mock(KisStockRankingClient.class);
+  private final StockRankingService service =
+      new StockRankingService(stringRedisTemplate, objectMapper, kisStockRankingClient);
+
+  @BeforeEach
+  void setUp() {
+    when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+  }
+
+  @Test
+  void fallsBackToKisWhenRedisReadUnavailable() {
+    RankingResDTO.RankingItem item =
+        new RankingResDTO.RankingItem(1, "005930", "삼성전자", 70000L, 100L, null, 1000L, null);
+    when(valueOperations.get(RankingType.VOLUME.getRedisKey()))
+        .thenThrow(new RedisConnectionFailureException("redis down"));
+    when(kisStockRankingClient.fetchRanking(RankingType.VOLUME)).thenReturn(List.of(item));
+
+    RankingResDTO.RankingResponse result = service.findRanking("volume");
+
+    assertThat(result.items()).containsExactly(item);
+    verify(kisStockRankingClient).fetchRanking(RankingType.VOLUME);
+  }
+
+  @Test
+  void returnsEmptyRankingWhenRedisAndKisAreUnavailable() {
+    when(valueOperations.get(RankingType.VOLUME.getRedisKey()))
+        .thenThrow(new RedisConnectionFailureException("redis down"));
+    when(kisStockRankingClient.fetchRanking(RankingType.VOLUME))
+        .thenThrow(new IllegalStateException("kis unavailable"));
+
+    RankingResDTO.RankingResponse result = service.findRanking("volume");
+
+    assertThat(result.type()).isEqualTo("volume");
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void ignoresRedisWriteFailureAfterKisFallbackSucceeds() {
+    RankingResDTO.RankingItem item =
+        new RankingResDTO.RankingItem(1, "005930", "삼성전자", 70000L, 100L, null, 1000L, null);
+    when(valueOperations.get(RankingType.VOLUME.getRedisKey())).thenReturn(null);
+    when(kisStockRankingClient.fetchRanking(RankingType.VOLUME)).thenReturn(List.of(item));
+    org.mockito.Mockito.doThrow(new RedisConnectionFailureException("redis down"))
+        .when(valueOperations)
+        .set(anyString(), anyString(), any());
+
+    RankingResDTO.RankingResponse result = service.findRanking("volume");
+
+    assertThat(result.items()).containsExactly(item);
+  }
+}

--- a/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImplTest.java
@@ -425,6 +425,45 @@ class RecommendationQueryServiceImplTest {
   }
 
   @Test
+  void rejectsRecommendationDetailBeyondDisplayWindow() {
+    ReflectionTestUtils.setField(service, "cacheDisplayMaxAgeSeconds", 120L);
+    Recommendation recommendation =
+        Recommendation.builder()
+            .id(1L)
+            .ranking(1)
+            .tickerCode("005930")
+            .companyName("삼성전자")
+            .modelGeneratedAt(generatedAt("2026-06-01T09:55:00+09:00"))
+            .build();
+    when(recommendationRepository.findById(1L)).thenReturn(Optional.of(recommendation));
+
+    assertThatThrownBy(() -> service.findRecommendationDetail(1L))
+        .isInstanceOf(GeneralException.class)
+        .extracting("code")
+        .isEqualTo(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
+  }
+
+  @Test
+  void rejectsRecommendationDetailByStockCodeWhenStaleDisplayIsDisabled() {
+    ReflectionTestUtils.setField(service, "allowStaleDisplay", false);
+    Recommendation recommendation =
+        Recommendation.builder()
+            .id(1L)
+            .ranking(1)
+            .tickerCode("005930")
+            .companyName("삼성전자")
+            .modelGeneratedAt(generatedAt("2026-06-01T09:55:00+09:00"))
+            .build();
+    when(recommendationRepository.findByTickerCodeIgnoreCase("005930"))
+        .thenReturn(Optional.of(recommendation));
+
+    assertThatThrownBy(() -> service.findRecommendationDetail("005930"))
+        .isInstanceOf(GeneralException.class)
+        .extracting("code")
+        .isEqualTo(RecommendationErrorCode.MODEL_RECOMMENDATION_UNAVAILABLE);
+  }
+
+  @Test
   void marksRecommendationDetailAsStaleWhenGeneratedAtIsMissing() {
     Recommendation recommendation =
         Recommendation.builder().id(1L).ranking(1).tickerCode("005930").companyName("삼성전자").build();

--- a/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/recommendation/service/query/RecommendationQueryServiceImplTest.java
@@ -43,6 +43,8 @@ class RecommendationQueryServiceImplTest {
     ReflectionTestUtils.setField(service, "includeRecommendationDiagnostics", false);
     ReflectionTestUtils.setField(service, "cacheReadEnabled", false);
     ReflectionTestUtils.setField(service, "cacheMaxAgeSeconds", 180L);
+    ReflectionTestUtils.setField(service, "cacheDisplayMaxAgeSeconds", 86_400L);
+    ReflectionTestUtils.setField(service, "allowStaleDisplay", true);
     ReflectionTestUtils.setField(service, "cacheMaxFutureSkewSeconds", 5L);
     ReflectionTestUtils.setField(
         service, "clock", Clock.fixed(Instant.parse("2026-06-01T01:01:00Z"), ZoneOffset.UTC));
@@ -277,8 +279,41 @@ class RecommendationQueryServiceImplTest {
   }
 
   @Test
-  void rejectsStaleCachedRecommendationsBeforeReturningRows() {
+  void returnsStaleCachedRecommendationsForDisplayWithoutCallingAi() {
     ReflectionTestUtils.setField(service, "cacheReadEnabled", true);
+    Recommendation stale =
+        Recommendation.builder()
+            .id(1L)
+            .tickerCode("005930")
+            .companyName("삼성전자")
+            .ranking(1)
+            .modelBundleId("BUNDLE-TEST")
+            .modelGeneratedAt(generatedAt("2026-06-01T09:55:00+09:00"))
+            .modelAsof("2026-06-01T09:54:00+09:00")
+            .build();
+    when(recommendationRepository.findByModelGeneratedAtIsNotNull()).thenReturn(List.of(stale));
+    when(recommendationRepository.findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            generatedAt("2026-06-01T09:55:00+09:00"), "BUNDLE-TEST"))
+        .thenReturn(List.of(stale));
+
+    RecommendationResDTO.RecommendationListDTO result = service.findRecommendationList();
+
+    assertThat(result.getModelReason()).isEqualTo("cached_recommendations");
+    assertThat(result.getMode()).isEqualTo("cached");
+    assertThat(result.getStale()).isTrue();
+    assertThat(result.getStaleReason()).isEqualTo("cache_stale");
+    assertThat(result.getSafeToEnableOrderActions()).isFalse();
+    assertThat(result.getLiveTradingAllowed()).isFalse();
+    verify(recommendationRepository)
+        .findByModelGeneratedAtAndModelBundleIdOrderByRankingAsc(
+            generatedAt("2026-06-01T09:55:00+09:00"), "BUNDLE-TEST");
+    verifyNoInteractions(aiServerClient);
+  }
+
+  @Test
+  void rejectsCachedRecommendationsBeyondDisplayWindow() {
+    ReflectionTestUtils.setField(service, "cacheReadEnabled", true);
+    ReflectionTestUtils.setField(service, "cacheDisplayMaxAgeSeconds", 120L);
     Recommendation stale =
         Recommendation.builder()
             .id(1L)
@@ -346,13 +381,61 @@ class RecommendationQueryServiceImplTest {
   @Test
   void findsRecommendationDetailById() {
     Recommendation recommendation =
-        Recommendation.builder().id(1L).ranking(1).tickerCode("005930").companyName("삼성전자").build();
+        Recommendation.builder()
+            .id(1L)
+            .ranking(1)
+            .tickerCode("005930")
+            .companyName("삼성전자")
+            .modelGeneratedAt(generatedAt("2026-06-01T10:00:00+09:00"))
+            .build();
     when(recommendationRepository.findById(1L)).thenReturn(Optional.of(recommendation));
 
     RecommendationResDTO.RecommendationDetailDTO result = service.findRecommendationDetail(1L);
 
     assertThat(result.getRecommendationId()).isEqualTo(1L);
     assertThat(result.getStockCode()).isEqualTo("005930");
+    assertThat(result.getCacheAgeSec()).isEqualTo(60L);
+    assertThat(result.getStale()).isFalse();
+    assertThat(result.getStaleReason()).isNull();
+    assertThat(result.getAdvisoryOnly()).isTrue();
+    assertThat(result.getSafeToEnableOrderActions()).isFalse();
+    assertThat(result.getLiveTradingAllowed()).isFalse();
     verify(recommendationRepository).findById(1L);
+  }
+
+  @Test
+  void marksRecommendationDetailAsStaleWhenGeneratedAtExceedsFreshWindow() {
+    Recommendation recommendation =
+        Recommendation.builder()
+            .id(1L)
+            .ranking(1)
+            .tickerCode("005930")
+            .companyName("삼성전자")
+            .modelGeneratedAt(generatedAt("2026-06-01T09:55:00+09:00"))
+            .build();
+    when(recommendationRepository.findById(1L)).thenReturn(Optional.of(recommendation));
+
+    RecommendationResDTO.RecommendationDetailDTO result = service.findRecommendationDetail(1L);
+
+    assertThat(result.getCacheAgeSec()).isEqualTo(360L);
+    assertThat(result.getStale()).isTrue();
+    assertThat(result.getStaleReason()).isEqualTo("cache_stale");
+    assertThat(result.getSafeToEnableOrderActions()).isFalse();
+    assertThat(result.getLiveTradingAllowed()).isFalse();
+  }
+
+  @Test
+  void marksRecommendationDetailAsStaleWhenGeneratedAtIsMissing() {
+    Recommendation recommendation =
+        Recommendation.builder().id(1L).ranking(1).tickerCode("005930").companyName("삼성전자").build();
+    when(recommendationRepository.findById(1L)).thenReturn(Optional.of(recommendation));
+
+    RecommendationResDTO.RecommendationDetailDTO result = service.findRecommendationDetail(1L);
+
+    assertThat(result.getCacheAgeSec()).isNull();
+    assertThat(result.getStale()).isTrue();
+    assertThat(result.getStaleReason()).isEqualTo("recommendation_generated_at_missing");
+    assertThat(result.getSafeToEnableOrderActions()).isFalse();
+    assertThat(result.getLiveTradingAllowed()).isFalse();
   }
 }


### PR DESCRIPTION
## 내용
- `/api/recommendations`가 최신 AI 계산 실패 시 저장된 추천 cache를 읽도록 보강했습니다.
- fresh window는 기본 180초, display window는 기본 86400초로 분리했습니다. display 가능한 stale 추천은 `stale=true/cache_stale`로 보여주되 자동매매 권한은 계속 false입니다.
- recommendation detail 응답에도 `cacheAgeSec`, `stale`, `staleReason`, `advisoryOnly`, `safeToEnableOrderActions=false`, `liveTradingAllowed=false`를 내려줍니다.
- BE `startSession`에서 선택 추천의 bundle mismatch, `modelGeneratedAt` missing/future/stale를 AI readiness/start 호출 전에 fail-closed합니다.
- AI gRPC timeout을 method별로 분리했습니다.
- Redis 장애 시 chart/ranking API가 500으로 터지지 않게 graceful degradation을 추가했습니다.
- 기본 profile `ddl-auto`를 `validate`로 바꿔 서버에서 Hibernate auto DDL mutation을 막았습니다. dev profile은 update 유지입니다.
- paper 자동매매 interval은 DTO/service/scheduler에서 60초 미만을 거부합니다.

## 배경
- GPT Pro E2E 점검에서 추천 조회 503, 단일 5초 AI timeout, Redis 500, ddl-auto update, 10초 paper interval gap이 server paper 출범 blocker로 확인됐습니다.
- 이후 GPT Pro v2/v3 재검증에서 남은 P0였던 상세 stale metadata와 BE direct start stale gate까지 닫았습니다.

## 검증
- `./gradlew --no-daemon test --tests RecommendationQueryServiceImplTest --tests AutoTradingCommandServiceImplTest --tests MarketIndexRedisServiceTest --tests StockRankingServiceTest --tests AutoTradingOperationSchedulerTest --tests AiServerClientTest`
- 결과: 66 tests, failures/errors 0, skipped 0
- `./gradlew --no-daemon spotlessCheck` PASS
- `git diff --check` PASS

## 남은 운영 proof
- post-fix full-stack E2E smoke
- recommendation cache seed/refresh proof
- DB schema validation under `ddl-auto=validate`
- runtime safety flags 확인: `safeToEnableLiveActions=false`, `liveTradingAllowed=false`, `registryMutated=false`, KIS virtual/paper only

## 안전
- live/real 주문 경로 추가 없음
- stale 추천은 표시 가능하지만 BE direct start에서 서버가 다시 차단합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 자동 거래 최소 주기가 60초 이상으로 강화되었습니다.
  * 추천 데이터의 캐시 상태 정보(나이, 신선도, 사유)를 응답에 추가했습니다.

* **버그 수정**
  * Redis 접근 실패 시 서비스 복원력을 향상시켰습니다.
  * 외부 서비스 통신 타임아웃을 요청 유형별로 세분화하여 안정성을 개선했습니다.

* **테스트**
  * 유효성 검증 및 캐시 신선도 시나리오 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->