### PR TITLE
추천 종목 가격·차트 조회 안정화

### DIFF
--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockResolverService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockResolverService.java
@@ -44,13 +44,28 @@ public class StockResolverService {
   }
 
   private Stock fetchAndRegister(String ticker) {
-    String stockName = kisStockBasicInfoClient.fetchStockName(ticker);
+    String stockName = fetchStockNameOrTicker(ticker);
     try {
       Stock stock = stockRegistrationService.saveIfAbsent(ticker, stockName);
       log.info("외부 종목 기본정보 DB 등록 완료. ticker={}, name={}", ticker, stock.getName());
       return stock;
     } catch (DataIntegrityViolationException e) {
       return stockRepository.findByTicker(ticker).orElseThrow(() -> e);
+    }
+  }
+
+  private String fetchStockNameOrTicker(String ticker) {
+    try {
+      return kisStockBasicInfoClient.fetchStockName(ticker);
+    } catch (StockException e) {
+      if (e.getCode() != StockErrorCode.KIS_STOCK_BASIC_INFO_API_FAILED) {
+        throw e;
+      }
+      log.warn(
+          "종목 기본정보 조회 실패로 ticker fallback을 사용합니다. ticker={}, reason={}",
+          ticker,
+          e.getCode().getCode());
+      return ticker;
     }
   }
 

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockSummaryRedisService.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/StockSummaryRedisService.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 public class StockSummaryRedisService {
 
   private static final String SUMMARY_KEY_PREFIX = "stock:summary:v2:";
-  private static final Duration SUMMARY_CACHE_TTL = Duration.ofSeconds(30);
+  private static final Duration SUMMARY_CACHE_TTL = Duration.ofMinutes(5);
 
   private final StringRedisTemplate stringRedisTemplate;
   private final ObjectMapper objectMapper;

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockChartQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockChartQueryServiceImpl.java
@@ -31,6 +31,8 @@ public class StockChartQueryServiceImpl implements StockChartQueryService {
   private static final Duration ONE_DAY_FETCH_LOCK_TTL = Duration.ofSeconds(20);
   private static final Duration ONE_DAY_FETCH_WAIT_INTERVAL = Duration.ofMillis(300);
   private static final int ONE_DAY_FETCH_WAIT_ATTEMPTS = 50;
+  private static final int CHART_FETCH_ATTEMPTS = 3;
+  private static final Duration CHART_FETCH_RETRY_DELAY = Duration.ofMillis(700);
 
   private final StockResolverService stockResolverService;
   private final StockChartRedisService stockChartRedisService;
@@ -93,7 +95,7 @@ public class StockChartQueryServiceImpl implements StockChartQueryService {
 
     try {
       List<StockChartResDTO.DataPoint> dataPoints =
-          kisStockChartClient.fetchChart(stock.getTicker(), chartRange);
+          fetchChartWithRetry(stock.getTicker(), chartRange);
       StockChartResDTO.Chart chart =
           new StockChartResDTO.Chart(
               stock.getTicker(),
@@ -112,6 +114,36 @@ public class StockChartQueryServiceImpl implements StockChartQueryService {
         releaseOneDayFetchLock(stock.getTicker(), lockToken);
       }
     }
+  }
+
+  private List<StockChartResDTO.DataPoint> fetchChartWithRetry(
+      String ticker, StockChartRange chartRange) {
+    StockException lastException = null;
+    for (int attempt = 1; attempt <= CHART_FETCH_ATTEMPTS; attempt++) {
+      try {
+        return kisStockChartClient.fetchChart(ticker, chartRange);
+      } catch (StockException e) {
+        lastException = e;
+        if (!isRetryableKisChartError(e) || attempt == CHART_FETCH_ATTEMPTS) {
+          throw e;
+        }
+        log.warn(
+            "종목 차트 KIS 조회 재시도. ticker={}, range={}, attempt={}/{}, reason={}",
+            ticker,
+            chartRange.getValue(),
+            attempt,
+            CHART_FETCH_ATTEMPTS,
+            e.getCode().getCode());
+        sleep(CHART_FETCH_RETRY_DELAY);
+      }
+    }
+    throw lastException == null
+        ? new StockException(StockErrorCode.KIS_STOCK_CHART_API_FAILED)
+        : lastException;
+  }
+
+  private boolean isRetryableKisChartError(StockException e) {
+    return e.getCode() == StockErrorCode.KIS_STOCK_CHART_API_FAILED;
   }
 
   private boolean acquireOneDayFetchLock(String ticker, String lockToken) {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImpl.java
@@ -8,7 +8,6 @@ import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceClie
 import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceWebSocketClient;
 import com.example.elephantfinancelab_be.domain.stocks.service.StockResolverService;
 import com.example.elephantfinancelab_be.domain.stocks.service.StockSummaryRedisService;
-import java.time.Duration;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class StockQueryServiceImpl implements StockQueryService {
 
   private static final int SUMMARY_FETCH_ATTEMPTS = 3;
-  private static final Duration SUMMARY_FETCH_RETRY_DELAY = Duration.ofMillis(400);
 
   private final StockResolverService stockResolverService;
   private final StockSummaryRedisService stockSummaryRedisService;
@@ -47,39 +45,28 @@ public class StockQueryServiceImpl implements StockQueryService {
   }
 
   private StockResDTO.Summary fetchSummaryWithRetry(Stock stock) {
-    StockException lastException = null;
-    for (int attempt = 1; attempt <= SUMMARY_FETCH_ATTEMPTS; attempt++) {
-      try {
-        return kisStockPriceClient.fetchSummary(stock);
-      } catch (StockException e) {
-        lastException = e;
-        if (!isRetryableKisSummaryError(e) || attempt == SUMMARY_FETCH_ATTEMPTS) {
-          throw e;
-        }
-        log.warn(
-            "종목 요약 KIS 조회 재시도. ticker={}, attempt={}/{}, reason={}",
-            stock.getTicker(),
-            attempt,
-            SUMMARY_FETCH_ATTEMPTS,
-            e.getCode().getCode());
-        sleep(SUMMARY_FETCH_RETRY_DELAY);
+    return fetchSummaryWithRetry(stock, 1);
+  }
+
+  private StockResDTO.Summary fetchSummaryWithRetry(Stock stock, int attempt) {
+    try {
+      return kisStockPriceClient.fetchSummary(stock);
+    } catch (StockException e) {
+      if (!isRetryableKisSummaryError(e) || attempt >= SUMMARY_FETCH_ATTEMPTS) {
+        throw e;
       }
+      log.warn(
+          "종목 요약 KIS 조회 재시도. ticker={}, attempt={}/{}, reason={}",
+          stock.getTicker(),
+          attempt,
+          SUMMARY_FETCH_ATTEMPTS,
+          e.getCode().getCode());
+      return fetchSummaryWithRetry(stock, attempt + 1);
     }
-    throw lastException == null
-        ? new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED)
-        : lastException;
   }
 
   private boolean isRetryableKisSummaryError(StockException e) {
     return e.getCode() == StockErrorCode.KIS_STOCK_PRICE_API_FAILED;
-  }
-
-  private void sleep(Duration duration) {
-    try {
-      Thread.sleep(duration.toMillis());
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
   }
 
   private StockResDTO.Summary findCachedSummary(String ticker) {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImpl.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceClie
 import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceWebSocketClient;
 import com.example.elephantfinancelab_be.domain.stocks.service.StockResolverService;
 import com.example.elephantfinancelab_be.domain.stocks.service.StockSummaryRedisService;
+import java.time.Duration;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StockQueryServiceImpl implements StockQueryService {
+
+  private static final int SUMMARY_FETCH_ATTEMPTS = 3;
+  private static final Duration SUMMARY_FETCH_RETRY_DELAY = Duration.ofMillis(400);
 
   private final StockResolverService stockResolverService;
   private final StockSummaryRedisService stockSummaryRedisService;
@@ -36,10 +40,46 @@ public class StockQueryServiceImpl implements StockQueryService {
     }
 
     Stock stock = stockResolverService.resolve(normalizedTicker);
-    StockResDTO.Summary summary = kisStockPriceClient.fetchSummary(stock);
+    StockResDTO.Summary summary = fetchSummaryWithRetry(stock);
     saveSummaryCache(summary);
     kisStockPriceWebSocketClient.subscribe(stock.getTicker());
     return summary;
+  }
+
+  private StockResDTO.Summary fetchSummaryWithRetry(Stock stock) {
+    StockException lastException = null;
+    for (int attempt = 1; attempt <= SUMMARY_FETCH_ATTEMPTS; attempt++) {
+      try {
+        return kisStockPriceClient.fetchSummary(stock);
+      } catch (StockException e) {
+        lastException = e;
+        if (!isRetryableKisSummaryError(e) || attempt == SUMMARY_FETCH_ATTEMPTS) {
+          throw e;
+        }
+        log.warn(
+            "종목 요약 KIS 조회 재시도. ticker={}, attempt={}/{}, reason={}",
+            stock.getTicker(),
+            attempt,
+            SUMMARY_FETCH_ATTEMPTS,
+            e.getCode().getCode());
+        sleep(SUMMARY_FETCH_RETRY_DELAY);
+      }
+    }
+    throw lastException == null
+        ? new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED)
+        : lastException;
+  }
+
+  private boolean isRetryableKisSummaryError(StockException e) {
+    return e.getCode() == StockErrorCode.KIS_STOCK_PRICE_API_FAILED;
+  }
+
+  private void sleep(Duration duration) {
+    try {
+      Thread.sleep(duration.toMillis());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   private StockResDTO.Summary findCachedSummary(String ticker) {

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/StockResolverServiceTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/StockResolverServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.elephantfinancelab_be.domain.stocks.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -61,5 +62,18 @@ class StockResolverServiceTest {
     assertThat(result).isSameAs(stock);
     verify(kisStockBasicInfoClient).fetchStockName("006400");
     verify(stockRegistrationService).saveIfAbsent("006400", "006400");
+  }
+
+  @Test
+  void propagatesBasicInfoExceptionWhenErrorIsNotApiFailure() {
+    StockException exception =
+        new StockException(StockErrorCode.KIS_STOCK_BASIC_INFO_RESPONSE_PARSE_FAILED);
+    when(stockRepository.findByTicker("006400")).thenReturn(Optional.empty());
+    when(kisStockBasicInfoClient.fetchStockName("006400")).thenThrow(exception);
+
+    assertThatThrownBy(() -> service.resolve("006400")).isSameAs(exception);
+
+    verify(kisStockBasicInfoClient).fetchStockName("006400");
+    verifyNoInteractions(stockRegistrationService);
   }
 }

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/StockResolverServiceTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/StockResolverServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
 import com.example.elephantfinancelab_be.domain.stocks.repository.StockRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -44,5 +46,20 @@ class StockResolverServiceTest {
     assertThat(result).isSameAs(stock);
     verify(kisStockBasicInfoClient).fetchStockName("203650");
     verify(stockRegistrationService).saveIfAbsent("203650", "드림시큐리티");
+  }
+
+  @Test
+  void registersTickerFallbackWhenVirtualBasicInfoApiIsUnavailable() {
+    Stock stock = Stock.builder().ticker("006400").name("006400").build();
+    when(stockRepository.findByTicker("006400")).thenReturn(Optional.empty());
+    when(kisStockBasicInfoClient.fetchStockName("006400"))
+        .thenThrow(new StockException(StockErrorCode.KIS_STOCK_BASIC_INFO_API_FAILED));
+    when(stockRegistrationService.saveIfAbsent("006400", "006400")).thenReturn(stock);
+
+    Stock result = service.resolve("006400");
+
+    assertThat(result).isSameAs(stock);
+    verify(kisStockBasicInfoClient).fetchStockName("006400");
+    verify(stockRegistrationService).saveIfAbsent("006400", "006400");
   }
 }

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImplTest.java
@@ -1,8 +1,10 @@
 package com.example.elephantfinancelab_be.domain.stocks.service.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +49,21 @@ class StockQueryServiceImplTest {
   }
 
   @Test
+  void fetchesSummaryAndCachesWhenFirstKisAttemptSucceeds() {
+    StockResDTO.Summary fetched = summary(72500L);
+    when(stockSummaryRedisService.find("005930")).thenReturn(null);
+    when(stockResolverService.resolve("005930")).thenReturn(stock);
+    when(kisStockPriceClient.fetchSummary(stock)).thenReturn(fetched);
+
+    StockResDTO.Summary result = service.getSummary("005930");
+
+    assertThat(result).isSameAs(fetched);
+    verify(kisStockPriceClient, times(1)).fetchSummary(stock);
+    verify(stockSummaryRedisService).save(fetched);
+    verify(kisStockPriceWebSocketClient).subscribe("005930");
+  }
+
+  @Test
   void retriesTransientKisSummaryFailureAndCachesSuccess() {
     StockResDTO.Summary fetched = summary(72500L);
     when(stockSummaryRedisService.find("005930")).thenReturn(null);
@@ -58,9 +75,58 @@ class StockQueryServiceImplTest {
     StockResDTO.Summary result = service.getSummary("005930");
 
     assertThat(result).isSameAs(fetched);
-    verify(kisStockPriceClient, org.mockito.Mockito.times(2)).fetchSummary(stock);
+    verify(kisStockPriceClient, times(2)).fetchSummary(stock);
     verify(stockSummaryRedisService).save(fetched);
     verify(kisStockPriceWebSocketClient).subscribe("005930");
+  }
+
+  @Test
+  void succeedsAfterTwoRetriesForTransientKisSummaryFailure() {
+    StockResDTO.Summary fetched = summary(72800L);
+    when(stockSummaryRedisService.find("005930")).thenReturn(null);
+    when(stockResolverService.resolve("005930")).thenReturn(stock);
+    when(kisStockPriceClient.fetchSummary(stock))
+        .thenThrow(new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED))
+        .thenThrow(new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED))
+        .thenReturn(fetched);
+
+    StockResDTO.Summary result = service.getSummary("005930");
+
+    assertThat(result).isSameAs(fetched);
+    verify(kisStockPriceClient, times(3)).fetchSummary(stock);
+    verify(stockSummaryRedisService).save(fetched);
+    verify(kisStockPriceWebSocketClient).subscribe("005930");
+  }
+
+  @Test
+  void propagatesLastExceptionWhenAllTransientKisSummaryAttemptsFail() {
+    StockException first = new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
+    StockException second = new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
+    StockException last = new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
+    when(stockSummaryRedisService.find("005930")).thenReturn(null);
+    when(stockResolverService.resolve("005930")).thenReturn(stock);
+    when(kisStockPriceClient.fetchSummary(stock)).thenThrow(first, second, last);
+
+    assertThatThrownBy(() -> service.getSummary("005930")).isSameAs(last);
+
+    verify(kisStockPriceClient, times(3)).fetchSummary(stock);
+    verify(stockSummaryRedisService, never()).save(org.mockito.Mockito.any());
+    verify(kisStockPriceWebSocketClient, never()).subscribe("005930");
+  }
+
+  @Test
+  void propagatesNonRetryableKisSummaryFailureWithoutRetry() {
+    StockException exception =
+        new StockException(StockErrorCode.KIS_STOCK_PRICE_RESPONSE_PARSE_FAILED);
+    when(stockSummaryRedisService.find("005930")).thenReturn(null);
+    when(stockResolverService.resolve("005930")).thenReturn(stock);
+    when(kisStockPriceClient.fetchSummary(stock)).thenThrow(exception);
+
+    assertThatThrownBy(() -> service.getSummary("005930")).isSameAs(exception);
+
+    verify(kisStockPriceClient, times(1)).fetchSummary(stock);
+    verify(stockSummaryRedisService, never()).save(org.mockito.Mockito.any());
+    verify(kisStockPriceWebSocketClient, never()).subscribe("005930");
   }
 
   private StockResDTO.Summary summary(long price) {

--- a/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImplTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/domain/stocks/service/query/StockQueryServiceImplTest.java
@@ -1,0 +1,77 @@
+package com.example.elephantfinancelab_be.domain.stocks.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.elephantfinancelab_be.domain.stocks.dto.res.StockResDTO;
+import com.example.elephantfinancelab_be.domain.stocks.entity.Stock;
+import com.example.elephantfinancelab_be.domain.stocks.exception.StockException;
+import com.example.elephantfinancelab_be.domain.stocks.exception.code.StockErrorCode;
+import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceClient;
+import com.example.elephantfinancelab_be.domain.stocks.service.KisStockPriceWebSocketClient;
+import com.example.elephantfinancelab_be.domain.stocks.service.StockResolverService;
+import com.example.elephantfinancelab_be.domain.stocks.service.StockSummaryRedisService;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class StockQueryServiceImplTest {
+
+  private final Stock stock = Stock.builder().ticker("005930").name("삼성전자").build();
+  private final StockResolverService stockResolverService = mock(StockResolverService.class);
+  private final StockSummaryRedisService stockSummaryRedisService =
+      mock(StockSummaryRedisService.class);
+  private final KisStockPriceClient kisStockPriceClient = mock(KisStockPriceClient.class);
+  private final KisStockPriceWebSocketClient kisStockPriceWebSocketClient =
+      mock(KisStockPriceWebSocketClient.class);
+  private final StockQueryServiceImpl service =
+      new StockQueryServiceImpl(
+          stockResolverService,
+          stockSummaryRedisService,
+          kisStockPriceClient,
+          kisStockPriceWebSocketClient);
+
+  @Test
+  void returnsCachedSummaryWithoutCallingKis() {
+    StockResDTO.Summary cached = summary(72000L);
+    when(stockSummaryRedisService.find("005930")).thenReturn(cached);
+
+    StockResDTO.Summary result = service.getSummary("005930");
+
+    assertThat(result).isSameAs(cached);
+    verify(kisStockPriceClient, never()).fetchSummary(stock);
+    verify(kisStockPriceWebSocketClient).subscribe("005930");
+  }
+
+  @Test
+  void retriesTransientKisSummaryFailureAndCachesSuccess() {
+    StockResDTO.Summary fetched = summary(72500L);
+    when(stockSummaryRedisService.find("005930")).thenReturn(null);
+    when(stockResolverService.resolve("005930")).thenReturn(stock);
+    when(kisStockPriceClient.fetchSummary(stock))
+        .thenThrow(new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED))
+        .thenReturn(fetched);
+
+    StockResDTO.Summary result = service.getSummary("005930");
+
+    assertThat(result).isSameAs(fetched);
+    verify(kisStockPriceClient, org.mockito.Mockito.times(2)).fetchSummary(stock);
+    verify(stockSummaryRedisService).save(fetched);
+    verify(kisStockPriceWebSocketClient).subscribe("005930");
+  }
+
+  private StockResDTO.Summary summary(long price) {
+    return StockResDTO.Summary.builder()
+        .stockName("삼성전자")
+        .ticker("005930")
+        .currentPriceKrw(price)
+        .changeAmountKrw(100L)
+        .changeRate(BigDecimal.valueOf(0.14))
+        .signCode("2")
+        .updatedAt(LocalDateTime.parse("2026-06-04T09:30:00"))
+        .build();
+  }
+}


### PR DESCRIPTION
## 작업 내용
- 추천 종목 summary 캐시 TTL을 5분으로 늘려 같은 화면에서 KIS 현재가 재호출이 폭주하지 않도록 했습니다.
- KIS 현재가 summary 조회와 종목 차트 조회에 retry를 추가했습니다.
- KIS virtual에서 종목 기본정보 API가 막히는 경우 ticker fallback으로 가격 조회가 계속 진행되도록 했습니다.
- 관련 단위 테스트를 추가했습니다.

## 확인한 문제
- 추천 화면에서 10개 추천은 내려오지만 일부 종목 가격이 `가격 정보 없음`으로 표시되었습니다.
- 추천 상세 차트가 KIS 일시 실패/rate 영향으로 502가 날 수 있었습니다.
- 일부 추천 종목은 로컬 stocks 테이블에 없고, virtual KIS 기본정보 API가 막히면서 가격 조회까지 실패했습니다.

## 검증
- BE focused test PASS
- FE와 함께 서버를 켠 상태에서 추천 10개 가격 API 10/10 status 200 확인
- 추천 상세 차트 API 200, chart points 63 확인
- merge는 하지 않았습니다. 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선사항

* **안정성 강화**
  * 주식 차트 조회에 자동 재시도 로직 추가
  * 주식 요약 정보 조회 시 재시도 메커니즘 구현
  * API 호출 실패 시 폴백 기능 추가

* **성능 최적화**
  * 주식 요약 캐시 만료 시간 30초에서 5분으로 확대

* **Tests**
  * 폴백 동작 및 재시도 로직 검증을 위한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->