### PR TITLE
fix: KIS 시세와 포트폴리오 설정 분리

### DIFF
--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisAccessTokenClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisAccessTokenClient.java
@@ -81,6 +81,20 @@ public class KisAccessTokenClient {
     return waitForIssuedToken(tokenRedisKey);
   }
 
+  public void invalidateAccessToken() {
+    invalidateAccessToken(kisProperties.getAppKey(), kisProperties.getBaseUrl());
+  }
+
+  public void invalidateAccessToken(String appKey, String baseUrl) {
+    String tokenRedisKey = tokenRedisKey(appKey, baseUrl);
+    stringRedisTemplate.delete(tokenRedisKey);
+    stringRedisTemplate.delete(tokenLockRedisKey(tokenRedisKey));
+    log.info(
+        "한국투자증권 접근 토큰 캐시 무효화. baseUrl={}, appKey={}",
+        normalizedBaseUrl(baseUrl),
+        maskedAppKey(appKey));
+  }
+
   private String issueAccessToken(
       String tokenRedisKey, String appKey, String appSecret, String baseUrl) {
     try {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisStockRankingClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/chart/service/KisStockRankingClient.java
@@ -45,9 +45,15 @@ public class KisStockRankingClient {
               .uri(rankingUri(type))
               .timeout(REQUEST_TIMEOUT)
               .header("content-type", MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8")
-              .header("authorization", "Bearer " + accessTokenClient.getAccessToken())
-              .header("appkey", kisProperties.getAppKey())
-              .header("appsecret", kisProperties.getAppSecret())
+              .header(
+                  "authorization",
+                  "Bearer "
+                      + accessTokenClient.getAccessToken(
+                          kisProperties.getFinancialAppKeyOrDefault(),
+                          kisProperties.getFinancialAppSecretOrDefault(),
+                          kisProperties.getFinancialBaseUrlOrDefault()))
+              .header("appkey", kisProperties.getFinancialAppKeyOrDefault())
+              .header("appsecret", kisProperties.getFinancialAppSecretOrDefault())
               .header("tr_id", type.getTrId())
               .header("custtype", "P")
               .GET()
@@ -109,7 +115,7 @@ public class KisStockRankingClient {
   }
 
   private URI rankingUri(RankingType type) {
-    String baseUrl = kisProperties.getBaseUrl();
+    String baseUrl = kisProperties.getFinancialBaseUrlOrDefault();
     String normalizedBaseUrl =
         baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
     return URI.create(

--- a/src/main/java/com/example/elephantfinancelab_be/domain/portfolio/service/KisPortfolioClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/portfolio/service/KisPortfolioClient.java
@@ -50,6 +50,7 @@ public class KisPortfolioClient {
   private static final String INITIAL_TR_CONT = "";
   private static final String NEXT_TR_CONT = "N";
   private static final int MAX_CONTINUOUS_REQUESTS = 10;
+  private static final int MAX_FETCH_ATTEMPTS = 3;
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
   private static final DateTimeFormatter KIS_DATE_FORMATTER = DateTimeFormatter.BASIC_ISO_DATE;
   private static final DateTimeFormatter KIS_TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmmss");
@@ -129,56 +130,76 @@ public class KisPortfolioClient {
   private KisResponse fetch(
       String path, String trId, Map<String, String> params, String trCont, String apiName) {
     try {
-      HttpRequest.Builder builder =
-          HttpRequest.newBuilder()
-              .uri(uri(path, params))
-              .timeout(REQUEST_TIMEOUT)
-              .header("content-type", MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8")
-              .header("authorization", "Bearer " + accessTokenClient.getAccessToken())
-              .header("appkey", kisProperties.getAppKey())
-              .header("appsecret", kisProperties.getAppSecret())
-              .header("tr_id", trId)
-              .header("custtype", "P")
-              .GET();
-      if (hasText(trCont)) {
-        builder.header("tr_cont", trCont);
-      }
+      for (int attempt = 0; attempt < MAX_FETCH_ATTEMPTS; attempt++) {
+        HttpRequest.Builder builder =
+            HttpRequest.newBuilder()
+                .uri(uri(path, params))
+                .timeout(REQUEST_TIMEOUT)
+                .header("content-type", MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8")
+                .header("authorization", "Bearer " + accessTokenClient.getAccessToken())
+                .header("appkey", kisProperties.getAppKey())
+                .header("appsecret", kisProperties.getAppSecret())
+                .header("tr_id", trId)
+                .header("custtype", "P")
+                .GET();
+        if (hasText(trCont)) {
+          builder.header("tr_cont", trCont);
+        }
 
-      HttpResponse<String> response =
-          httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
-      if (response.statusCode() < 200 || response.statusCode() >= 300) {
-        log.warn(
-            "code={}, message={}, api={}, trId={}, status={}, account={}",
-            PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED.getCode(),
-            PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED.getMessage(),
-            apiName,
-            trId,
-            response.statusCode(),
-            kisProperties.maskedAccount());
-        throw new PortfolioException(PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED);
-      }
+        HttpResponse<String> response =
+            httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+          if (isExpiredToken(response.body()) && attempt == 0) {
+            accessTokenClient.invalidateAccessToken();
+            continue;
+          }
+          if (isRateLimited(response.body()) && attempt < MAX_FETCH_ATTEMPTS - 1) {
+            sleepBeforeRetry(attempt);
+            continue;
+          }
+          log.warn(
+              "code={}, message={}, api={}, trId={}, status={}, account={}, kisError={}",
+              PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED.getCode(),
+              PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED.getMessage(),
+              apiName,
+              trId,
+              response.statusCode(),
+              kisProperties.maskedAccount(),
+              kisErrorSummary(response.body()));
+          throw new PortfolioException(PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED);
+        }
 
-      JsonNode root = readTree(response.body(), apiName);
-      if (!"0".equals(root.path("rt_cd").asText())) {
-        log.warn(
-            "code={}, message={}, api={}, trId={}, msgCd={}, msg={}, account={}",
-            PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED.getCode(),
-            PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED.getMessage(),
-            apiName,
-            trId,
-            root.path("msg_cd").asText(),
-            root.path("msg1").asText(),
-            kisProperties.maskedAccount());
-        throw new PortfolioException(PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED);
-      }
+        JsonNode root = readTree(response.body(), apiName);
+        if (!"0".equals(root.path("rt_cd").asText())) {
+          if (isExpiredToken(root) && attempt == 0) {
+            accessTokenClient.invalidateAccessToken();
+            continue;
+          }
+          if (isRateLimited(root) && attempt < MAX_FETCH_ATTEMPTS - 1) {
+            sleepBeforeRetry(attempt);
+            continue;
+          }
+          log.warn(
+              "code={}, message={}, api={}, trId={}, msgCd={}, msg={}, account={}",
+              PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED.getCode(),
+              PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED.getMessage(),
+              apiName,
+              trId,
+              root.path("msg_cd").asText(),
+              root.path("msg1").asText(),
+              kisProperties.maskedAccount());
+          throw new PortfolioException(PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED);
+        }
 
-      return new KisResponse(root, response.headers().firstValue("tr_cont").orElse(""));
+        return new KisResponse(root, response.headers().firstValue("tr_cont").orElse(""));
+      }
     } catch (IOException e) {
       throw new PortfolioException(PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED, e);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new PortfolioException(PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED, e);
     }
+    throw new PortfolioException(PortfolioErrorCode.KIS_PORTFOLIO_API_FAILED);
   }
 
   private JsonNode readTree(String body, String apiName) {
@@ -193,6 +214,58 @@ public class KisPortfolioClient {
           kisProperties.maskedAccount());
       throw new PortfolioException(PortfolioErrorCode.KIS_PORTFOLIO_RESPONSE_PARSE_FAILED, e);
     }
+  }
+
+  private String kisErrorSummary(String body) {
+    if (body == null || body.isBlank()) {
+      return "empty";
+    }
+    try {
+      JsonNode root = objectMapper.readTree(body);
+      String msgCd = root.path("msg_cd").asText("");
+      String msg = root.path("msg1").asText("");
+      if (!msgCd.isBlank() || !msg.isBlank()) {
+        return "msg_cd=" + msgCd + ", msg1=" + msg;
+      }
+    } catch (IOException ignored) {
+      // Fall through to a compact body preview for non-JSON KIS errors.
+    }
+    String compact = body.replaceAll("\\s+", " ").trim();
+    return compact.length() > 180 ? compact.substring(0, 180) + "..." : compact;
+  }
+
+  private boolean isExpiredToken(String body) {
+    if (body == null || body.isBlank()) {
+      return false;
+    }
+    try {
+      return isExpiredToken(objectMapper.readTree(body));
+    } catch (IOException ignored) {
+      return false;
+    }
+  }
+
+  private boolean isExpiredToken(JsonNode root) {
+    return "EGW00123".equals(root.path("msg_cd").asText());
+  }
+
+  private boolean isRateLimited(String body) {
+    if (body == null || body.isBlank()) {
+      return false;
+    }
+    try {
+      return isRateLimited(objectMapper.readTree(body));
+    } catch (IOException ignored) {
+      return false;
+    }
+  }
+
+  private boolean isRateLimited(JsonNode root) {
+    return "EGW00201".equals(root.path("msg_cd").asText());
+  }
+
+  private void sleepBeforeRetry(int attempt) throws InterruptedException {
+    Thread.sleep(500L * (attempt + 1));
   }
 
   private Account resolveAccount() {

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockBasicInfoClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockBasicInfoClient.java
@@ -37,7 +37,8 @@ public class KisStockBasicInfoClient {
     this.kisProperties = kisProperties;
     this.accessTokenClient = accessTokenClient;
     this.objectMapper = objectMapper;
-    this.webClient = builder.baseUrl(normalizedBaseUrl(kisProperties.getBaseUrl())).build();
+    this.webClient =
+        builder.baseUrl(normalizedBaseUrl(kisProperties.getFinancialBaseUrlOrDefault())).build();
   }
 
   public String fetchStockName(String ticker) {
@@ -107,9 +108,13 @@ public class KisStockBasicInfoClient {
   private void applyKisHeaders(HttpHeaders headers) {
     headers.setContentType(
         MediaType.parseMediaType(MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8"));
-    headers.setBearerAuth(accessTokenClient.getAccessToken());
-    headers.set("appkey", kisProperties.getAppKey());
-    headers.set("appsecret", kisProperties.getAppSecret());
+    headers.setBearerAuth(
+        accessTokenClient.getAccessToken(
+            kisProperties.getFinancialAppKeyOrDefault(),
+            kisProperties.getFinancialAppSecretOrDefault(),
+            kisProperties.getFinancialBaseUrlOrDefault()));
+    headers.set("appkey", kisProperties.getFinancialAppKeyOrDefault());
+    headers.set("appsecret", kisProperties.getFinancialAppSecretOrDefault());
     headers.set("tr_id", BASIC_INFO_TR_ID);
     headers.set("custtype", "P");
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockChartClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockChartClient.java
@@ -75,7 +75,8 @@ public class KisStockChartClient {
     this.kisProperties = kisProperties;
     this.accessTokenClient = accessTokenClient;
     this.objectMapper = objectMapper;
-    this.webClient = builder.baseUrl(normalizedBaseUrl(kisProperties.getBaseUrl())).build();
+    this.webClient =
+        builder.baseUrl(normalizedBaseUrl(kisProperties.getFinancialBaseUrlOrDefault())).build();
   }
 
   public List<StockChartResDTO.DataPoint> fetchChart(String ticker, StockChartRange range) {
@@ -236,9 +237,13 @@ public class KisStockChartClient {
   private void applyKisHeaders(HttpHeaders headers, String trId) {
     headers.setContentType(
         MediaType.parseMediaType(MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8"));
-    headers.setBearerAuth(accessTokenClient.getAccessToken());
-    headers.set("appkey", kisProperties.getAppKey());
-    headers.set("appsecret", kisProperties.getAppSecret());
+    headers.setBearerAuth(
+        accessTokenClient.getAccessToken(
+            kisProperties.getFinancialAppKeyOrDefault(),
+            kisProperties.getFinancialAppSecretOrDefault(),
+            kisProperties.getFinancialBaseUrlOrDefault()));
+    headers.set("appkey", kisProperties.getFinancialAppKeyOrDefault());
+    headers.set("appsecret", kisProperties.getFinancialAppSecretOrDefault());
     headers.set("tr_id", trId);
     headers.set("custtype", "P");
   }

--- a/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceClient.java
+++ b/src/main/java/com/example/elephantfinancelab_be/domain/stocks/service/KisStockPriceClient.java
@@ -77,48 +77,66 @@ public class KisStockPriceClient {
 
   private JsonNode fetchCurrentPriceOutput(Stock stock) {
     try {
-      HttpRequest request =
-          HttpRequest.newBuilder()
-              .uri(currentPriceUri(stock.getTicker()))
-              .timeout(REQUEST_TIMEOUT)
-              .header("content-type", MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8")
-              .header("authorization", "Bearer " + accessTokenClient.getAccessToken())
-              .header("appkey", kisProperties.getAppKey())
-              .header("appsecret", kisProperties.getAppSecret())
-              .header("tr_id", CURRENT_PRICE_TR_ID)
-              .header("custtype", "P")
-              .GET()
-              .build();
+      for (int attempt = 0; attempt < 2; attempt++) {
+        HttpRequest request =
+            HttpRequest.newBuilder()
+                .uri(currentPriceUri(stock.getTicker()))
+                .timeout(REQUEST_TIMEOUT)
+                .header("content-type", MediaType.APPLICATION_JSON_VALUE + "; charset=utf-8")
+                .header(
+                    "authorization",
+                    "Bearer "
+                        + accessTokenClient.getAccessToken(
+                            kisProperties.getFinancialAppKeyOrDefault(),
+                            kisProperties.getFinancialAppSecretOrDefault(),
+                            kisProperties.getFinancialBaseUrlOrDefault()))
+                .header("appkey", kisProperties.getFinancialAppKeyOrDefault())
+                .header("appsecret", kisProperties.getFinancialAppSecretOrDefault())
+                .header("tr_id", CURRENT_PRICE_TR_ID)
+                .header("custtype", "P")
+                .GET()
+                .build();
 
-      HttpResponse<String> response =
-          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-      if (response.statusCode() < 200 || response.statusCode() >= 300) {
-        log.warn(
-            "code={}, message={}, status={}",
-            StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getCode(),
-            StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getMessage(),
-            response.statusCode());
-        throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
+        HttpResponse<String> response =
+            httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+          if (isExpiredToken(response.body()) && attempt == 0) {
+            invalidateFinancialAccessToken();
+            continue;
+          }
+          log.warn(
+              "code={}, message={}, status={}, kisError={}",
+              StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getCode(),
+              StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getMessage(),
+              response.statusCode(),
+              kisErrorSummary(response.body()));
+          throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
+        }
+
+        JsonNode root = objectMapper.readTree(response.body());
+        if (!"0".equals(root.path("rt_cd").asText())) {
+          if (isExpiredToken(root) && attempt == 0) {
+            invalidateFinancialAccessToken();
+            continue;
+          }
+          log.warn(
+              "code={}, message={}, msg_cd={}, msg={}",
+              StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getCode(),
+              StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getMessage(),
+              root.path("msg_cd").asText(),
+              root.path("msg1").asText());
+          throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
+        }
+
+        return root.path("output");
       }
-
-      JsonNode root = objectMapper.readTree(response.body());
-      if (!"0".equals(root.path("rt_cd").asText())) {
-        log.warn(
-            "code={}, message={}, msg_cd={}, msg={}",
-            StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getCode(),
-            StockErrorCode.KIS_STOCK_PRICE_API_FAILED.getMessage(),
-            root.path("msg_cd").asText(),
-            root.path("msg1").asText());
-        throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
-      }
-
-      return root.path("output");
     } catch (IOException e) {
       throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED, e);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED, e);
     }
+    throw new StockException(StockErrorCode.KIS_STOCK_PRICE_API_FAILED);
   }
 
   private URI currentPriceUri(String ticker) {
@@ -126,10 +144,48 @@ public class KisStockPriceClient {
     params.put("FID_COND_MRKT_DIV_CODE", KRX_MARKET_DIV_CODE);
     params.put("FID_INPUT_ISCD", ticker);
 
-    String baseUrl = kisProperties.getBaseUrl();
+    String baseUrl = kisProperties.getFinancialBaseUrlOrDefault();
     String normalizedBaseUrl =
         baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
     return URI.create(normalizedBaseUrl + CURRENT_PRICE_PATH + "?" + queryString(params));
+  }
+
+  private String kisErrorSummary(String body) {
+    if (body == null || body.isBlank()) {
+      return "empty";
+    }
+    try {
+      JsonNode root = objectMapper.readTree(body);
+      String msgCd = root.path("msg_cd").asText("");
+      String msg = root.path("msg1").asText("");
+      if (!msgCd.isBlank() || !msg.isBlank()) {
+        return "msg_cd=" + msgCd + ", msg1=" + msg;
+      }
+    } catch (IOException ignored) {
+      // Fall through to a compact body preview for non-JSON KIS errors.
+    }
+    String compact = body.replaceAll("\\s+", " ").trim();
+    return compact.length() > 180 ? compact.substring(0, 180) + "..." : compact;
+  }
+
+  private void invalidateFinancialAccessToken() {
+    accessTokenClient.invalidateAccessToken(
+        kisProperties.getFinancialAppKeyOrDefault(), kisProperties.getFinancialBaseUrlOrDefault());
+  }
+
+  private boolean isExpiredToken(String body) {
+    if (body == null || body.isBlank()) {
+      return false;
+    }
+    try {
+      return isExpiredToken(objectMapper.readTree(body));
+    } catch (IOException ignored) {
+      return false;
+    }
+  }
+
+  private boolean isExpiredToken(JsonNode root) {
+    return "EGW00123".equals(root.path("msg_cd").asText());
   }
 
   private String queryString(Map<String, String> params) {

--- a/src/main/java/com/example/elephantfinancelab_be/global/config/KisProperties.java
+++ b/src/main/java/com/example/elephantfinancelab_be/global/config/KisProperties.java
@@ -98,11 +98,6 @@ public class KisProperties {
   void validateOfficialEndpointMatchesMode() {
     validateModeEndpoint("base-url", getBaseUrl(), mode.baseUrl(), mode.other().baseUrl());
     validateModeEndpoint(
-        "financial-base-url",
-        getFinancialBaseUrlOrDefault(),
-        mode.baseUrl(),
-        mode.other().baseUrl());
-    validateModeEndpoint(
         "websocket-url", getWebsocketUrl(), mode.websocketUrl(), mode.other().websocketUrl());
   }
 

--- a/src/test/java/com/example/elephantfinancelab_be/global/config/KisPropertiesTest.java
+++ b/src/test/java/com/example/elephantfinancelab_be/global/config/KisPropertiesTest.java
@@ -38,6 +38,19 @@ class KisPropertiesTest {
   }
 
   @Test
+  void allowsRealFinancialEndpointInVirtualModeForPaperPortfolioAndMarketDataSplit() {
+    KisProperties properties = new KisProperties();
+    properties.setMode(Mode.VIRTUAL);
+    properties.setFinancialBaseUrl("https://openapi.koreainvestment.com:9443");
+
+    properties.validateOfficialEndpointMatchesMode();
+
+    assertThat(properties.getBaseUrl()).isEqualTo("https://openapivts.koreainvestment.com:29443");
+    assertThat(properties.getFinancialBaseUrlOrDefault())
+        .isEqualTo("https://openapi.koreainvestment.com:9443");
+  }
+
+  @Test
   void rejectsAnExplicitRealRestEndpointInVirtualMode() {
     KisProperties properties = new KisProperties();
     properties.setMode(Mode.VIRTUAL);
@@ -49,12 +62,13 @@ class KisPropertiesTest {
   }
 
   @Test
-  void rejectsAnExplicitVirtualFinancialEndpointInRealMode() {
+  void allowsVirtualFinancialEndpointInRealModeForExplicitLocalOverrides() {
     KisProperties properties = new KisProperties();
     properties.setFinancialBaseUrl("https://openapivts.koreainvestment.com:29443");
 
-    assertThatThrownBy(properties::validateOfficialEndpointMatchesMode)
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("kis.financial-base-url does not match kis.mode=real");
+    properties.validateOfficialEndpointMatchesMode();
+
+    assertThat(properties.getFinancialBaseUrlOrDefault())
+        .isEqualTo("https://openapivts.koreainvestment.com:29443");
   }
 }


### PR DESCRIPTION
## 요약

- 로컬 AI-BE-FE 연결 검증 중 발생한 추천/차트/포트폴리오 KIS 설정 문제를 분리했습니다.
- 시세/차트/랭킹은 financial KIS 설정을 사용하고, 포트폴리오/거래내역은 virtual KIS 모의계좌 설정을 유지합니다.
- KIS 만료 토큰과 rate-limit 상황에서 fail-fast 502로 끝나지 않도록 제한적인 재시도를 추가했습니다.

## 원인

- 기존에는 `kis.mode` 하나가 포트폴리오와 시세/차트 KIS 호출에 함께 적용되었습니다.
- `KIS_MODE=virtual` 상태에서 시세/차트도 virtual endpoint/key 조합으로 호출되어 일부 화면이 비거나 500이 발생할 수 있었습니다.
- Redis에 만료된 KIS token이 남아 있으면 portfolio balance/trades가 `EGW00123`으로 502가 났습니다.
- summary/trades 동시 조회 시 KIS `EGW00201` rate-limit이 발생할 수 있었습니다.

## 주요 변경

- market-data clients는 `KIS_FINANCIAL_*`와 `KIS_FINANCIAL_BASE_URL` 사용
  - current price
  - stock chart
  - basic info
  - chart ranking
- portfolio client는 기존 virtual KIS account/TR 유지
  - balance `VTTC8434R`
  - trades `VTTC0081R`
- `KisProperties`에서 `KIS_MODE=virtual` + financial real base URL 조합 허용
- KIS access token cache invalidate API 추가
- `EGW00123` 만료 token 감지 시 token cache 삭제 후 1회 재시도
- portfolio `EGW00201` rate-limit 감지 시 backoff 재시도
- KIS non-2xx 응답의 `msg_cd/msg1`를 sanitized log로 남겨 원인 추적 가능하게 함

## 로컬 검증

실제 로그인 로컬 FE 세션에서 확인:

```text
/api/recommendations        200
/api/chart/ranking          200
/api/stocks/042660/summary  200
/api/portfolio/summary      200
/api/portfolio/trades       200
```

화면 확인:

- 추천 10개 + 가격/등락률 표시
- 차트 랭킹 표시
- My 수익률/포트폴리오 표시
- 포트폴리오 거래내역 표시

테스트:

```text
./gradlew test --tests com.example.elephantfinancelab_be.global.config.KisPropertiesTest \
  --tests com.example.elephantfinancelab_be.domain.stocks.service.query.StockQueryServiceImplTest \
  --tests com.example.elephantfinancelab_be.domain.stocks.service.query.StockInfoQueryServiceImplTest \
  --tests com.example.elephantfinancelab_be.domain.portfolio.service.query.PortfolioQueryServiceImplTest

BUILD SUCCESSFUL

./gradlew spotlessCheck

BUILD SUCCESSFUL
```

## 안전

- secret/token 원문 로그 출력 없음
- account는 masked logging 유지
- portfolio는 KIS virtual mode 유지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 포트폴리오 조회 요청 시 재시도 로직 추가로 일시적 오류에 대한 안정성 개선
  * 주식 가격 조회 요청 시 토큰 만료 감지 및 재시도 기능 추가
  * API 요청 헤더 및 엔드포인트 설정 정규화로 안정성 강화

* **테스트**
  * 금융 서비스 엔드포인트 설정 관련 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->